### PR TITLE
Decompose --strict into --strict-structure, --strict-encoding, --strict-state

### DIFF
--- a/.changeset/strict-decompose.md
+++ b/.changeset/strict-decompose.md
@@ -1,0 +1,14 @@
+---
+"@galaxy-tool-util/schema": minor
+"@galaxy-tool-util/cli": minor
+---
+
+Decompose --strict into --strict-structure, --strict-encoding, --strict-state
+
+Add three granular strict validation flags to all gxwf commands (validate, lint, convert, roundtrip + tree variants). --strict remains as shorthand for all three.
+
+- --strict-structure: reject unknown keys via Effect Schema onExcessProperty: "error"
+- --strict-encoding: reject JSON-string tool_state (native) and tool_state field misuse (format2)
+- --strict-state: promote skipped/unconverted steps to failures (exit 2)
+
+Schema package: new strict-checks.ts with checkStrictEncoding/checkStrictStructure, RoundtripResult gains encodingErrors/structureErrors with multi-stage validation, StepValidationResult gains skippedReason.

--- a/packages/cli/src/bin/gxwf.ts
+++ b/packages/cli/src/bin/gxwf.ts
@@ -11,6 +11,7 @@ import { runLint } from "../commands/lint.js";
 import { runLintTree } from "../commands/lint-tree.js";
 import { runValidateWorkflow } from "../commands/validate-workflow.js";
 import { runValidateTree } from "../commands/validate-tree.js";
+import { addStrictOptions } from "../commands/strict-options.js";
 
 const program = new Command();
 
@@ -19,19 +20,20 @@ program
   .description("Galaxy workflow operations — validate, clean, lint, convert (single-file and tree)")
   .version("1.0.0");
 
-program
-  .command("validate")
-  .description("Validate Galaxy workflow files (structure + optional tool state)")
-  .argument("<file>", "Workflow file (.ga, .gxwf.yml)")
-  .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
-  .option("--no-tool-state", "Skip tool state validation")
-  .option("--cache-dir <dir>", "Tool cache directory")
-  .option("--mode <mode>", "Validation backend: effect (default) or json-schema", "effect")
-  .option(
-    "--tool-schema-dir <dir>",
-    "Directory of pre-exported per-tool JSON Schemas (for offline json-schema mode)",
-  )
-  .action(runValidateWorkflow);
+addStrictOptions(
+  program
+    .command("validate")
+    .description("Validate Galaxy workflow files (structure + optional tool state)")
+    .argument("<file>", "Workflow file (.ga, .gxwf.yml)")
+    .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
+    .option("--no-tool-state", "Skip tool state validation")
+    .option("--cache-dir <dir>", "Tool cache directory")
+    .option("--mode <mode>", "Validation backend: effect (default) or json-schema", "effect")
+    .option(
+      "--tool-schema-dir <dir>",
+      "Directory of pre-exported per-tool JSON Schemas (for offline json-schema mode)",
+    ),
+).action(runValidateWorkflow);
 
 program
   .command("clean")
@@ -42,70 +44,75 @@ program
   .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
   .action(runClean);
 
-program
-  .command("lint")
-  .description("Lint Galaxy workflow — structural checks, best practices, tool state validation")
-  .argument("<file>", "Workflow file (.ga, .gxwf.yml)")
-  .option("--skip-best-practices", "Skip annotation/creator/license/label checks")
-  .option("--skip-state-validation", "Skip tool state validation against cached tool definitions")
-  .option("--cache-dir <dir>", "Tool cache directory (for state validation)")
-  .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
-  .option("--json", "Output structured JSON result")
-  .action(runLint);
+addStrictOptions(
+  program
+    .command("lint")
+    .description("Lint Galaxy workflow — structural checks, best practices, tool state validation")
+    .argument("<file>", "Workflow file (.ga, .gxwf.yml)")
+    .option("--skip-best-practices", "Skip annotation/creator/license/label checks")
+    .option("--skip-state-validation", "Skip tool state validation against cached tool definitions")
+    .option("--cache-dir <dir>", "Tool cache directory (for state validation)")
+    .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
+    .option("--json", "Output structured JSON result"),
+).action(runLint);
 
-program
-  .command("convert")
-  .description("Convert between native (.ga) and format2 (.gxwf.yml) formats")
-  .argument("<file>", "Workflow file (.ga, .gxwf.yml)")
-  .option("--to <format>", "Target format: native or format2 (infers opposite by default)")
-  .option("--output <file>", "Write result to file (default: stdout)")
-  .option("--compact", "Omit position info in format2 output")
-  .option("--json", "Force JSON output")
-  .option("--yaml", "Force YAML output")
-  .option("--format <fmt>", "Force source format (auto-detected by default)")
-  .option("--stateful", "Use cached tool definitions for schema-aware state re-encoding")
-  .option("--cache-dir <dir>", "Tool cache directory (for --stateful)")
-  .action(runConvert);
+addStrictOptions(
+  program
+    .command("convert")
+    .description("Convert between native (.ga) and format2 (.gxwf.yml) formats")
+    .argument("<file>", "Workflow file (.ga, .gxwf.yml)")
+    .option("--to <format>", "Target format: native or format2 (infers opposite by default)")
+    .option("--output <file>", "Write result to file (default: stdout)")
+    .option("--compact", "Omit position info in format2 output")
+    .option("--json", "Force JSON output")
+    .option("--yaml", "Force YAML output")
+    .option("--format <fmt>", "Force source format (auto-detected by default)")
+    .option("--stateful", "Use cached tool definitions for schema-aware state re-encoding")
+    .option("--cache-dir <dir>", "Tool cache directory (for --stateful)"),
+).action(runConvert);
 
-program
-  .command("roundtrip")
-  .description("Roundtrip-validate a native workflow: native → format2 → native, diff tool_state")
-  .argument("<file>", "Native workflow file (.ga)")
-  .option("--cache-dir <dir>", "Tool cache directory")
-  .option("--format <fmt>", "Force source format (must resolve to native)")
-  .option("--json", "Output structured JSON report")
-  .option("--errors-only", "Suppress benign diffs and clean steps from output")
-  .option("--benign-only", "Show only steps with benign diffs (no errors, no failures)")
-  .option("--brief", "Omit per-diff list; show only the one-line summary")
-  .action(runRoundtrip);
+addStrictOptions(
+  program
+    .command("roundtrip")
+    .description("Roundtrip-validate a native workflow: native → format2 → native, diff tool_state")
+    .argument("<file>", "Native workflow file (.ga)")
+    .option("--cache-dir <dir>", "Tool cache directory")
+    .option("--format <fmt>", "Force source format (must resolve to native)")
+    .option("--json", "Output structured JSON report")
+    .option("--errors-only", "Suppress benign diffs and clean steps from output")
+    .option("--benign-only", "Show only steps with benign diffs (no errors, no failures)")
+    .option("--brief", "Omit per-diff list; show only the one-line summary"),
+).action(runRoundtrip);
 
 // -- Tree (batch) variants --
 
-program
-  .command("validate-tree")
-  .description("Batch validate all workflows under a directory")
-  .argument("<dir>", "Directory to scan for workflows")
-  .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
-  .option("--no-tool-state", "Skip tool state validation")
-  .option("--cache-dir <dir>", "Tool cache directory")
-  .option("--mode <mode>", "Validation backend: effect (default) or json-schema", "effect")
-  .option(
-    "--tool-schema-dir <dir>",
-    "Directory of pre-exported per-tool JSON Schemas (for offline json-schema mode)",
-  )
-  .option("--json", "Output structured JSON report")
-  .action(runValidateTree);
+addStrictOptions(
+  program
+    .command("validate-tree")
+    .description("Batch validate all workflows under a directory")
+    .argument("<dir>", "Directory to scan for workflows")
+    .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
+    .option("--no-tool-state", "Skip tool state validation")
+    .option("--cache-dir <dir>", "Tool cache directory")
+    .option("--mode <mode>", "Validation backend: effect (default) or json-schema", "effect")
+    .option(
+      "--tool-schema-dir <dir>",
+      "Directory of pre-exported per-tool JSON Schemas (for offline json-schema mode)",
+    )
+    .option("--json", "Output structured JSON report"),
+).action(runValidateTree);
 
-program
-  .command("lint-tree")
-  .description("Batch lint all workflows under a directory")
-  .argument("<dir>", "Directory to scan for workflows")
-  .option("--skip-best-practices", "Skip annotation/creator/license/label checks")
-  .option("--skip-state-validation", "Skip tool state validation against cached tool definitions")
-  .option("--cache-dir <dir>", "Tool cache directory (for state validation)")
-  .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
-  .option("--json", "Output structured JSON report")
-  .action(runLintTree);
+addStrictOptions(
+  program
+    .command("lint-tree")
+    .description("Batch lint all workflows under a directory")
+    .argument("<dir>", "Directory to scan for workflows")
+    .option("--skip-best-practices", "Skip annotation/creator/license/label checks")
+    .option("--skip-state-validation", "Skip tool state validation against cached tool definitions")
+    .option("--cache-dir <dir>", "Tool cache directory (for state validation)")
+    .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
+    .option("--json", "Output structured JSON report"),
+).action(runLintTree);
 
 program
   .command("clean-tree")
@@ -116,31 +123,33 @@ program
   .option("--json", "Output structured JSON report")
   .action(runCleanTree);
 
-program
-  .command("convert-tree")
-  .description("Batch convert all workflows under a directory")
-  .argument("<dir>", "Directory to scan for workflows")
-  .option("--to <format>", "Target format: native or format2 (infers opposite by default)")
-  .option("--output-dir <dir>", "Write converted workflows to directory (required)")
-  .option("--compact", "Omit position info in format2 output")
-  .option("--report-json", "Output structured JSON report")
-  .option("--json", "Force JSON output for converted files")
-  .option("--yaml", "Force YAML output")
-  .option("--format <fmt>", "Force source format (auto-detected by default)")
-  .option("--stateful", "Use cached tool definitions for schema-aware state re-encoding")
-  .option("--cache-dir <dir>", "Tool cache directory (for --stateful)")
-  .action(runConvertTree);
+addStrictOptions(
+  program
+    .command("convert-tree")
+    .description("Batch convert all workflows under a directory")
+    .argument("<dir>", "Directory to scan for workflows")
+    .option("--to <format>", "Target format: native or format2 (infers opposite by default)")
+    .option("--output-dir <dir>", "Write converted workflows to directory (required)")
+    .option("--compact", "Omit position info in format2 output")
+    .option("--report-json", "Output structured JSON report")
+    .option("--json", "Force JSON output for converted files")
+    .option("--yaml", "Force YAML output")
+    .option("--format <fmt>", "Force source format (auto-detected by default)")
+    .option("--stateful", "Use cached tool definitions for schema-aware state re-encoding")
+    .option("--cache-dir <dir>", "Tool cache directory (for --stateful)"),
+).action(runConvertTree);
 
-program
-  .command("roundtrip-tree")
-  .description("Batch roundtrip-validate native workflows under a directory")
-  .argument("<dir>", "Directory to scan for native workflows")
-  .option("--cache-dir <dir>", "Tool cache directory")
-  .option("--format <fmt>", "Force source format (must resolve to native)")
-  .option("--json", "Output structured JSON report")
-  .option("--errors-only", "List only files with errors or failures")
-  .option("--benign-only", "List only files with benign diffs (no errors, no failures)")
-  .option("--brief", "Omit per-file lines; print only the aggregate summary")
-  .action(runRoundtripTree);
+addStrictOptions(
+  program
+    .command("roundtrip-tree")
+    .description("Batch roundtrip-validate native workflows under a directory")
+    .argument("<dir>", "Directory to scan for native workflows")
+    .option("--cache-dir <dir>", "Tool cache directory")
+    .option("--format <fmt>", "Force source format (must resolve to native)")
+    .option("--json", "Output structured JSON report")
+    .option("--errors-only", "List only files with errors or failures")
+    .option("--benign-only", "List only files with benign diffs (no errors, no failures)")
+    .option("--brief", "Omit per-file lines; print only the aggregate summary"),
+).action(runRoundtripTree);
 
 program.parse();

--- a/packages/cli/src/commands/convert-tree.ts
+++ b/packages/cli/src/commands/convert-tree.ts
@@ -7,6 +7,8 @@ import {
   toFormat2Stateful,
   toNative,
   toNativeStateful,
+  checkStrictEncoding,
+  checkStrictStructure,
   type ExpansionOptions,
   type StepConversionStatus,
   type WorkflowFormat,
@@ -15,10 +17,11 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, basename } from "node:path";
 import { loadToolInputsForWorkflow, type ToolLoadStatus } from "./stateful-tool-inputs.js";
 import { createDefaultResolver } from "./url-resolver.js";
+import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
 import { resolveFormat, serializeWorkflow } from "./workflow-io.js";
 import { collectTree, summarizeOutcomes, type TreeResult, type TreeSummary } from "./tree.js";
 
-export interface ConvertTreeOptions {
+export interface ConvertTreeOptions extends StrictOptions {
   to?: string;
   outputDir?: string;
   compact?: boolean;
@@ -62,9 +65,25 @@ export async function runConvertTree(dir: string, opts: ConvertTreeOptions): Pro
     }
   }
 
+  const strict = resolveStrictOptions(opts);
+
   const treeResult = await collectTree(dir, async (info, data) => {
     const sourceFormat = resolveFormat(data, opts.format);
     const targetFormat = resolveTargetFormat(sourceFormat, opts.to);
+
+    // Per-file strict checks on input
+    if (strict.strictEncoding) {
+      const encErrors = checkStrictEncoding(data, sourceFormat);
+      if (encErrors.length > 0) {
+        throw new Error(`Encoding: ${encErrors.join("; ")}`);
+      }
+    }
+    if (strict.strictStructure) {
+      const structErrors = checkStrictStructure(data, sourceFormat);
+      if (structErrors.length > 0) {
+        throw new Error(`Structure: ${structErrors.join("; ")}`);
+      }
+    }
 
     if (sourceFormat === targetFormat) {
       return {
@@ -121,6 +140,11 @@ export async function runConvertTree(dir: string, opts: ConvertTreeOptions): Pro
     const outPath = join(outputDir, outName);
     await mkdir(dirname(outPath), { recursive: true });
     await writeFile(outPath, serialized, "utf-8");
+
+    // --strict-state: require all stateful steps to convert successfully
+    if (strict.strictState && statefulSteps?.some((s) => !s.converted)) {
+      throw new Error("Strict state: all steps must convert successfully");
+    }
 
     return {
       relativePath: info.relativePath,

--- a/packages/cli/src/commands/convert.ts
+++ b/packages/cli/src/commands/convert.ts
@@ -7,6 +7,8 @@ import {
   toFormat2Stateful,
   toNative,
   toNativeStateful,
+  checkStrictEncoding,
+  checkStrictStructure,
   type ExpansionOptions,
   type StepConversionStatus,
   type WorkflowFormat,
@@ -14,6 +16,7 @@ import {
 import { dirname } from "node:path";
 import { loadToolInputsForWorkflow } from "./stateful-tool-inputs.js";
 import { createDefaultResolver } from "./url-resolver.js";
+import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
 import {
   readWorkflowFile,
   resolveFormat,
@@ -21,7 +24,7 @@ import {
   writeWorkflowOutput,
 } from "./workflow-io.js";
 
-export interface ConvertOptions {
+export interface ConvertOptions extends StrictOptions {
   to?: string;
   output?: string;
   compact?: boolean;
@@ -38,6 +41,27 @@ export async function runConvert(filePath: string, opts: ConvertOptions): Promis
 
   const sourceFormat = resolveFormat(data, opts.format);
   const targetFormat = resolveTargetFormat(sourceFormat, opts.to);
+  const strict = resolveStrictOptions(opts);
+
+  // Pre-conversion strict checks on input
+  if (strict.strictEncoding) {
+    const encErrors = checkStrictEncoding(data, sourceFormat);
+    if (encErrors.length > 0) {
+      console.error("Encoding errors:");
+      for (const e of encErrors) console.error(`  ${e}`);
+      process.exitCode = 2;
+      return;
+    }
+  }
+  if (strict.strictStructure) {
+    const structErrors = checkStrictStructure(data, sourceFormat);
+    if (structErrors.length > 0) {
+      console.error("Structure errors (strict):");
+      for (const e of structErrors) console.error(`  ${e}`);
+      process.exitCode = 2;
+      return;
+    }
+  }
 
   if (sourceFormat === targetFormat) {
     console.error(
@@ -99,6 +123,15 @@ export async function runConvert(filePath: string, opts: ConvertOptions): Promis
 
   if (stepStatuses !== null) {
     reportStepStatuses(stepStatuses);
+    // --strict-state: require all steps to convert successfully
+    if (strict.strictState) {
+      const hasFailures = stepStatuses.some((s) => !s.converted);
+      if (hasFailures) {
+        console.error("Strict state: all steps must convert successfully");
+        process.exitCode = 2;
+        return;
+      }
+    }
   }
 }
 

--- a/packages/cli/src/commands/lint-tree.ts
+++ b/packages/cli/src/commands/lint-tree.ts
@@ -3,10 +3,11 @@
  */
 import { ToolCache } from "@galaxy-tool-util/core";
 import { resolveFormat } from "./workflow-io.js";
+import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
 import { lintWorkflowReport, type LintReport } from "./lint.js";
 import { collectTree, summarizeOutcomes, type TreeResult, type TreeSummary } from "./tree.js";
 
-export interface LintTreeOptions {
+export interface LintTreeOptions extends StrictOptions {
   format?: string;
   skipBestPractices?: boolean;
   skipStateValidation?: boolean;
@@ -42,12 +43,15 @@ export async function runLintTree(dir: string, opts: LintTreeOptions): Promise<v
     }
   }
 
+  const strict = resolveStrictOptions(opts);
+
   const treeResult = await collectTree(dir, async (info, data) => {
     const format = resolveFormat(data, opts.format);
     const report = await lintWorkflowReport(info.path, data, format, {
       skipBestPractices: opts.skipBestPractices,
       skipStateValidation: opts.skipStateValidation,
       cache,
+      strict,
     });
     return { relativePath: info.relativePath, report } satisfies WorkflowLintResult;
   });

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -7,20 +7,28 @@ import {
   lintWorkflow,
   lintBestPracticesNative,
   lintBestPracticesFormat2,
+  checkStrictEncoding,
+  checkStrictStructure,
   type LintResult,
   type ExpansionOptions,
+  type WorkflowFormat,
 } from "@galaxy-tool-util/schema";
 import { dirname } from "node:path";
 import { renderStepResults } from "./render-results.js";
 import { readWorkflowFile, resolveFormat } from "./workflow-io.js";
 import { createDefaultResolver } from "./url-resolver.js";
 import {
+  resolveStrictOptions,
+  type StrictOptions,
+  type ResolvedStrictOptions,
+} from "./strict-options.js";
+import {
   validateNativeSteps,
   validateFormat2Steps,
   type StepValidationResult,
 } from "./validate-workflow.js";
 
-export interface LintOptions {
+export interface LintOptions extends StrictOptions {
   format?: string;
   skipBestPractices?: boolean;
   skipStateValidation?: boolean;
@@ -32,6 +40,7 @@ export interface LintReportOptions {
   skipBestPractices?: boolean;
   skipStateValidation?: boolean;
   cache?: ToolCache;
+  strict?: ResolvedStrictOptions;
 }
 
 export interface LintReport {
@@ -39,6 +48,8 @@ export interface LintReport {
   bestPractices: LintResult | null;
   stateValidation: StepValidationResult[] | null;
   stateSkipped: boolean;
+  encodingErrors: string[];
+  structureErrors: string[];
   exitCode: number;
 }
 
@@ -71,16 +82,28 @@ export async function runLint(filePath: string, opts: LintOptions): Promise<void
     }
   }
 
+  const strict = resolveStrictOptions(opts);
   const report = await lintWorkflowReport(filePath, data, format, {
     skipBestPractices: opts.skipBestPractices,
     skipStateValidation: opts.skipStateValidation,
     cache,
+    strict,
   });
 
   if (opts.json) {
     console.log(JSON.stringify(report, null, 2));
     process.exitCode = report.exitCode;
     return;
+  }
+
+  // Strict checks
+  if (report.encodingErrors.length > 0) {
+    console.error("Encoding errors:");
+    for (const e of report.encodingErrors) console.error(`  ${e}`);
+  }
+  if (report.structureErrors.length > 0) {
+    console.error("Structure errors (strict):");
+    for (const e of report.structureErrors) console.error(`  ${e}`);
   }
 
   // Structural lint
@@ -133,6 +156,19 @@ export async function lintWorkflowReport(
   format: string,
   opts: LintReportOptions,
 ): Promise<LintReport> {
+  const strict = opts.strict ?? {
+    strictStructure: false,
+    strictEncoding: false,
+    strictState: false,
+  };
+  const fmt = format as WorkflowFormat;
+
+  // Strict encoding check
+  const encodingErrors = strict.strictEncoding ? checkStrictEncoding(data, fmt) : [];
+
+  // Strict structure check
+  const structureErrors = strict.strictStructure ? checkStrictStructure(data, fmt) : [];
+
   // Phase 1: Structural lint (always runs)
   const structural = lintWorkflow(data);
 
@@ -178,10 +214,22 @@ export async function lintWorkflowReport(
   // Compute exit code: 0 = clean, 1 = warnings only, 2 = errors
   const merged = mergeLintResults(structural, bestPractices);
   const hasStateErrors = stateValidation?.some((r) => r.status === "fail") ?? false;
-  const hasErrors = merged.error_count > 0 || hasStateErrors;
+  const hasStrictErrors = encodingErrors.length > 0 || structureErrors.length > 0;
+  const hasStrictStateSkips =
+    strict.strictState && (stateValidation?.some((r) => r.status === "skip") ?? false);
+  const hasErrors =
+    merged.error_count > 0 || hasStateErrors || hasStrictErrors || hasStrictStateSkips;
   const hasWarnings = merged.warn_count > 0;
 
   const exitCode = hasErrors ? 2 : hasWarnings ? 1 : 0;
 
-  return { structural, bestPractices, stateValidation, stateSkipped, exitCode };
+  return {
+    structural,
+    bestPractices,
+    stateValidation,
+    stateSkipped,
+    encodingErrors,
+    structureErrors,
+    exitCode,
+  };
 }

--- a/packages/cli/src/commands/roundtrip-tree.ts
+++ b/packages/cli/src/commands/roundtrip-tree.ts
@@ -11,11 +11,12 @@ import {
 import { dirname, join } from "node:path";
 import { loadToolInputsForWorkflow, type ToolLoadStatus } from "./stateful-tool-inputs.js";
 import { createDefaultResolver } from "./url-resolver.js";
+import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
 import { resolveFormat } from "./workflow-io.js";
 import { collectTree, skipWorkflow } from "./tree.js";
 import { countDiffs } from "./roundtrip.js";
 
-export interface RoundtripTreeOptions {
+export interface RoundtripTreeOptions extends StrictOptions {
   cacheDir?: string;
   format?: string;
   json?: boolean;
@@ -40,11 +41,14 @@ export async function runRoundtripTree(dir: string, opts: RoundtripTreeOptions):
     console.warn("Tool cache is empty — all steps will fall back (no roundtrip possible)");
   }
 
+  const strict = resolveStrictOptions(opts);
+
   // Only native workflows are eligible; format2 files are skipped.
   const treeResult = await collectTree<FileOutcome>(
     dir,
     async (info, data) => {
       const sourceFormat = resolveFormat(data, opts.format);
+
       if (sourceFormat !== "native") {
         skipWorkflow(`not a native workflow (${sourceFormat})`);
       }
@@ -60,7 +64,15 @@ export async function runRoundtripTree(dir: string, opts: RoundtripTreeOptions):
         expansionOpts,
       );
       const failedLoads = toolStatus.filter((s) => !s.loaded);
-      const result = roundtripValidate(data, resolver);
+      const result = roundtripValidate(data, resolver, {
+        strictEncoding: strict.strictEncoding,
+        strictStructure: strict.strictStructure,
+        strictState: strict.strictState,
+      });
+      if (result.encodingErrors.length > 0 || result.structureErrors.length > 0) {
+        const allErrors = [...result.encodingErrors, ...result.structureErrors];
+        throw new Error(`Strict: ${allErrors.join("; ")}`);
+      }
       return {
         relativePath: info.relativePath,
         result,

--- a/packages/cli/src/commands/roundtrip.ts
+++ b/packages/cli/src/commands/roundtrip.ts
@@ -17,9 +17,10 @@ import {
 import { dirname } from "node:path";
 import { loadToolInputsForWorkflow } from "./stateful-tool-inputs.js";
 import { createDefaultResolver } from "./url-resolver.js";
+import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
 import { readWorkflowFile, resolveFormat } from "./workflow-io.js";
 
-export interface RoundtripOptions {
+export interface RoundtripOptions extends StrictOptions {
   cacheDir?: string;
   format?: string;
   json?: boolean;
@@ -36,6 +37,8 @@ export async function runRoundtrip(filePath: string, opts: RoundtripOptions): Pr
   if (!data) return;
 
   const sourceFormat = resolveFormat(data, opts.format);
+  const strict = resolveStrictOptions(opts);
+
   if (sourceFormat !== "native") {
     console.error(
       `Roundtrip source must be a native (.ga) workflow; got ${sourceFormat}.` +
@@ -67,15 +70,35 @@ export async function runRoundtrip(filePath: string, opts: RoundtripOptions): Pr
     }
   }
 
-  const result = roundtripValidate(data, resolver);
+  const result = roundtripValidate(data, resolver, {
+    strictEncoding: strict.strictEncoding,
+    strictStructure: strict.strictStructure,
+    strictState: strict.strictState,
+  });
 
   if (opts.json) {
     console.log(JSON.stringify(result, null, 2));
   } else {
+    // Report strict errors before step-level results
+    if (result.encodingErrors.length > 0) {
+      console.error("Encoding errors:");
+      for (const e of result.encodingErrors) console.error(`  ${e}`);
+    }
+    if (result.structureErrors.length > 0) {
+      console.error("Structure errors (strict):");
+      for (const e of result.structureErrors) console.error(`  ${e}`);
+    }
     reportResult(filePath, result, opts);
   }
 
-  process.exitCode = exitCodeFor(result);
+  let exitCode = exitCodeFor(result);
+
+  // --strict-state: require all steps to roundtrip (no skips/failures)
+  if (strict.strictState && result.stepResults.some((s) => !s.success)) {
+    exitCode = 2;
+  }
+
+  process.exitCode = exitCode;
 }
 
 export interface ReportFilter {

--- a/packages/cli/src/commands/strict-options.ts
+++ b/packages/cli/src/commands/strict-options.ts
@@ -1,0 +1,38 @@
+/**
+ * Strict validation options — decomposed into three orthogonal dimensions.
+ *
+ * --strict is shorthand for --strict-structure --strict-encoding --strict-state.
+ */
+import type { Command } from "commander";
+
+export interface StrictOptions {
+  strict?: boolean;
+  strictStructure?: boolean;
+  strictEncoding?: boolean;
+  strictState?: boolean;
+}
+
+export interface ResolvedStrictOptions {
+  strictStructure: boolean;
+  strictEncoding: boolean;
+  strictState: boolean;
+}
+
+/** Expand --strict shorthand into the three individual flags. */
+export function resolveStrictOptions(opts: StrictOptions): ResolvedStrictOptions {
+  const all = !!opts.strict;
+  return {
+    strictStructure: all || !!opts.strictStructure,
+    strictEncoding: all || !!opts.strictEncoding,
+    strictState: all || !!opts.strictState,
+  };
+}
+
+/** Register --strict, --strict-structure, --strict-encoding, --strict-state on a Commander command. */
+export function addStrictOptions(cmd: Command): Command {
+  return cmd
+    .option("--strict", "Shorthand for --strict-structure --strict-encoding --strict-state")
+    .option("--strict-structure", "Reject unknown keys at envelope/step level")
+    .option("--strict-encoding", "Reject JSON-string tool_state and format2 field misuse")
+    .option("--strict-state", "Require every tool step to validate; no skips allowed");
+}

--- a/packages/cli/src/commands/validate-tree.ts
+++ b/packages/cli/src/commands/validate-tree.ts
@@ -2,9 +2,14 @@
  * `gxwf validate-tree` — batch validate all workflows under a directory.
  */
 import { ToolCache } from "@galaxy-tool-util/core";
-import type { ExpansionOptions } from "@galaxy-tool-util/schema";
+import {
+  checkStrictEncoding,
+  checkStrictStructure,
+  type ExpansionOptions,
+} from "@galaxy-tool-util/schema";
 import { dirname } from "node:path";
 import { createDefaultResolver } from "./url-resolver.js";
+import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
 import { resolveFormat } from "./workflow-io.js";
 import {
   validateNativeSteps,
@@ -14,7 +19,7 @@ import {
 } from "./validate-workflow.js";
 import { collectTree, summarizeOutcomes, type TreeResult, type TreeSummary } from "./tree.js";
 
-export interface ValidateTreeOptions {
+export interface ValidateTreeOptions extends StrictOptions {
   format?: string;
   toolState?: boolean;
   cacheDir?: string;
@@ -61,8 +66,25 @@ export async function runValidateTree(dir: string, opts: ValidateTreeOptions): P
       mod.validateFormat2StepsJsonSchema(data, cache, opts.toolSchemaDir, prefix, expansionOpts);
   }
 
+  const strict = resolveStrictOptions(opts);
+
   const treeResult = await collectTree(dir, async (info, data) => {
     const format = resolveFormat(data, opts.format);
+
+    // Per-file strict checks
+    if (strict.strictEncoding) {
+      const encErrors = checkStrictEncoding(data, format);
+      if (encErrors.length > 0) {
+        throw new Error(`Encoding: ${encErrors.join("; ")}`);
+      }
+    }
+    if (strict.strictStructure) {
+      const structErrors = checkStrictStructure(data, format);
+      if (structErrors.length > 0) {
+        throw new Error(`Structure: ${structErrors.join("; ")}`);
+      }
+    }
+
     const expansionOpts: ExpansionOptions = {
       resolver: createDefaultResolver({ workflowDirectory: dirname(info.path) }),
     };
@@ -75,6 +97,11 @@ export async function runValidateTree(dir: string, opts: ValidateTreeOptions): P
         format === "native"
           ? await validateNative(data, cache, "", expansionOpts)
           : await validateF2(data, cache, "", expansionOpts);
+    }
+
+    // --strict-state: promote skips to failures
+    if (strict.strictState && steps.some((s) => s.status === "skip")) {
+      throw new Error("Strict state: skipped steps not allowed");
     }
 
     return { relativePath: info.relativePath, format, steps } satisfies WorkflowValidateResult;

--- a/packages/cli/src/commands/validate-workflow.ts
+++ b/packages/cli/src/commands/validate-workflow.ts
@@ -8,6 +8,8 @@ import {
   injectConnectionsIntoState,
   stripConnectedValues,
   scanForReplacements,
+  checkStrictEncoding,
+  checkStrictStructure,
   type NormalizedNativeStep,
   type NormalizedNativeWorkflow,
   type NormalizedFormat2Step,
@@ -23,12 +25,13 @@ import { isResolveError, loadCachedTool } from "./resolve-tool.js";
 import { createDefaultResolver } from "./url-resolver.js";
 import { renderStepResults } from "./render-results.js";
 import { readWorkflowFile, resolveFormat } from "./workflow-io.js";
+import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
 
 export type { WorkflowFormat } from "@galaxy-tool-util/schema";
 
 export type ValidationMode = "effect" | "json-schema";
 
-export interface ValidateWorkflowOptions {
+export interface ValidateWorkflowOptions extends StrictOptions {
   format?: string;
   toolState?: boolean;
   cacheDir?: string;
@@ -47,6 +50,8 @@ export interface StepValidationResult {
   toolVersion: string | null;
   status: "ok" | "fail" | "skip";
   errors: string[];
+  /** When status is "skip", explains why (e.g. "not_in_cache", "replacement_params", "no_version"). */
+  skippedReason?: string;
 }
 
 export async function runValidateWorkflow(
@@ -70,6 +75,30 @@ export async function runValidateWorkflow(
   if (mode === "json-schema") {
     const { runValidateWorkflowJsonSchema } = await import("./validate-workflow-json-schema.js");
     return runValidateWorkflowJsonSchema(data, format, opts, expansionOpts);
+  }
+
+  const strict = resolveStrictOptions(opts);
+
+  // --- strict encoding check (pre-normalization) ---
+  if (strict.strictEncoding) {
+    const encErrors = checkStrictEncoding(data, format);
+    if (encErrors.length > 0) {
+      console.error("Encoding errors:");
+      for (const e of encErrors) console.error(`  ${e}`);
+      process.exitCode = 2;
+      return;
+    }
+  }
+
+  // --- strict structure check (pre-normalization) ---
+  if (strict.strictStructure) {
+    const structErrors = checkStrictStructure(data, format);
+    if (structErrors.length > 0) {
+      console.error("Structure errors (strict):");
+      for (const e of structErrors) console.error(`  ${e}`);
+      process.exitCode = 2;
+      return;
+    }
   }
 
   // --- structural validation (effect mode) ---
@@ -122,6 +151,14 @@ export async function runValidateWorkflow(
   const stateOk = !results.some((r) => r.status === "fail");
 
   console.log(`\nTool state: ${validated} validated, ${skipped} skipped`);
+
+  // --- strict state: promote skips to failures ---
+  if (strict.strictState && results.some((r) => r.status === "skip")) {
+    console.error("Strict state: skipped steps not allowed");
+    process.exitCode = 2;
+    return;
+  }
+
   process.exitCode = structOk && stateOk ? 0 : 1;
 }
 
@@ -174,9 +211,10 @@ async function _validateNativeStep(
 ): Promise<StepValidationResult> {
   const resolved = await loadCachedTool(cache, toolId, toolVersion);
   if (isResolveError(resolved)) {
+    const skippedReason = resolved.kind === "no_version" ? "no_version" : "not_in_cache";
     const reason =
       resolved.kind === "no_version" ? `no version for ${toolId}` : `${toolId} not in cache`;
-    return { stepLabel, toolId, toolVersion, status: "skip", errors: [reason] };
+    return { stepLabel, toolId, toolVersion, status: "skip", errors: [reason], skippedReason };
   }
 
   const bundle: ToolParameterBundleModel = {
@@ -195,6 +233,7 @@ async function _validateNativeStep(
       toolVersion,
       status: "skip",
       errors: ["replacement parameters detected"],
+      skippedReason: "replacement_params",
     };
   }
 
@@ -215,6 +254,7 @@ async function _validateNativeStep(
       toolVersion,
       status: "skip",
       errors: ["unsupported parameter types"],
+      skippedReason: "unsupported_params",
     };
   }
 
@@ -283,9 +323,10 @@ async function _validateFormat2Step(
 ): Promise<StepValidationResult> {
   const resolved = await loadCachedTool(cache, toolId, toolVersion);
   if (isResolveError(resolved)) {
+    const skippedReason = resolved.kind === "no_version" ? "no_version" : "not_in_cache";
     const reason =
       resolved.kind === "no_version" ? `no version for ${toolId}` : `${toolId} not in cache`;
-    return { stepLabel, toolId, toolVersion, status: "skip", errors: [reason] };
+    return { stepLabel, toolId, toolVersion, status: "skip", errors: [reason], skippedReason };
   }
 
   const bundle: ToolParameterBundleModel = {
@@ -307,6 +348,7 @@ async function _validateFormat2Step(
       toolVersion,
       status: "skip",
       errors: ["unsupported parameter types"],
+      skippedReason: "unsupported_params",
     };
   }
 
@@ -357,6 +399,7 @@ async function _validateFormat2Step(
         toolVersion,
         status: "skip",
         errors: ["unsupported parameter types"],
+        skippedReason: "unsupported_params",
       };
     }
 

--- a/packages/cli/test/iwc-sweep.test.ts
+++ b/packages/cli/test/iwc-sweep.test.ts
@@ -8,8 +8,10 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import { readFile, readdir } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { ToolCache } from "@galaxy-tool-util/core";
+import { checkStrictEncoding, checkStrictStructure } from "@galaxy-tool-util/schema";
 import {
   validateNativeSteps,
   type StepValidationResult,
@@ -102,3 +104,119 @@ function runSweep(
 
 runSweep("native validation", validateNativeSteps);
 runSweep("native JSON Schema validation", validateNativeStepsJsonSchema);
+
+// --- Strict sweep suites ---
+
+describe.skipIf(!IWC_DIR)("IWC sweep: strict-encoding", { timeout: 300_000 }, () => {
+  let workflows: string[];
+
+  beforeAll(async () => {
+    workflows = await discoverNativeWorkflows(join(IWC_DIR!, "workflows"));
+  });
+
+  it("all IWC native workflows pass strict-encoding", () => {
+    const failures: Array<{ workflow: string; errors: string[] }> = [];
+    for (const wfPath of workflows) {
+      const raw = readFileSync(wfPath, "utf-8");
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      const errors = checkStrictEncoding(data, "native");
+      if (errors.length > 0) {
+        failures.push({ workflow: workflowId(wfPath), errors });
+      }
+    }
+
+    if (failures.length > 0) {
+      const details = failures.map((f) => `  ${f.workflow}: ${f.errors.join("; ")}`).join("\n");
+      expect.fail(`${failures.length} encoding failures:\n${details}`);
+    }
+  });
+});
+
+describe.skipIf(!IWC_DIR)("IWC sweep: strict-structure", { timeout: 300_000 }, () => {
+  let workflows: string[];
+
+  beforeAll(async () => {
+    workflows = await discoverNativeWorkflows(join(IWC_DIR!, "workflows"));
+  });
+
+  it("all IWC native workflows pass strict-structure", () => {
+    const failures: Array<{ workflow: string; errors: string[] }> = [];
+    for (const wfPath of workflows) {
+      const raw = readFileSync(wfPath, "utf-8");
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      const errors = checkStrictStructure(data, "native");
+      if (errors.length > 0) {
+        failures.push({ workflow: workflowId(wfPath), errors });
+      }
+    }
+
+    if (failures.length > 0) {
+      const details = failures.map((f) => `  ${f.workflow}: ${f.errors.join("; ")}`).join("\n");
+      expect.fail(`${failures.length} structure failures:\n${details}`);
+    }
+  });
+});
+
+describe.skipIf(!IWC_DIR)("IWC sweep: strict (all)", { timeout: 300_000 }, () => {
+  let workflows: string[];
+  let cache: ToolCache;
+
+  beforeAll(async () => {
+    workflows = await discoverNativeWorkflows(join(IWC_DIR!, "workflows"));
+    cache = new ToolCache();
+    await cache.index.load();
+  });
+
+  it("all IWC native workflows pass strict validation", async () => {
+    const failures: Array<{ workflow: string; phase: string; errors: string[] }> = [];
+    let skippedSteps = 0;
+
+    for (const wfPath of workflows) {
+      const raw = readFileSync(wfPath, "utf-8");
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+
+      // Encoding
+      const encErrors = checkStrictEncoding(data, "native");
+      if (encErrors.length > 0) {
+        failures.push({ workflow: workflowId(wfPath), phase: "encoding", errors: encErrors });
+        continue;
+      }
+
+      // Structure
+      const structErrors = checkStrictStructure(data, "native");
+      if (structErrors.length > 0) {
+        failures.push({ workflow: workflowId(wfPath), phase: "structure", errors: structErrors });
+        continue;
+      }
+
+      // State: check for skips (strict-state would reject these)
+      const results = await validateNativeSteps(data, cache);
+      const skips = results.filter((r) => r.status === "skip");
+      skippedSteps += skips.length;
+    }
+
+    console.log(`\nIWC strict sweep: ${skippedSteps} steps would be skipped by strict-state`);
+
+    if (failures.length > 0) {
+      const details = failures
+        .map((f) => `  ${f.workflow} [${f.phase}]: ${f.errors.join("; ")}`)
+        .join("\n");
+      expect.fail(`${failures.length} strict failures:\n${details}`);
+    }
+  });
+});

--- a/packages/cli/test/strict-lint.test.ts
+++ b/packages/cli/test/strict-lint.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { runLint } from "../src/commands/lint.js";
+import { createCliTestContext, type CliTestContext } from "./helpers/cli-test-context.js";
+import { seedAllTools, SIMPLE_TOOL_ID } from "./helpers/fixtures.js";
+
+describe("lint --strict-encoding", () => {
+  let ctx: CliTestContext;
+  beforeEach(async () => {
+    ctx = await createCliTestContext("strict-lint-enc");
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("reports encoding error for JSON-string tool_state", async () => {
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          tool_state: JSON.stringify({ input_text: "hello" }),
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "legacy.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runLint(wfPath, { cacheDir: ctx.tmpDir, strictEncoding: true });
+
+    expect(process.exitCode).toBe(2);
+    const errors = ctx.errSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(errors).toContain("Encoding errors");
+  });
+});
+
+describe("lint --strict-structure", () => {
+  let ctx: CliTestContext;
+  beforeEach(async () => {
+    ctx = await createCliTestContext("strict-lint-struct");
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("reports structure error for extra keys", async () => {
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {},
+      bogus_key: "bad",
+    };
+    const wfPath = join(ctx.tmpDir, "extra.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runLint(wfPath, {
+      cacheDir: ctx.tmpDir,
+      strictStructure: true,
+      skipStateValidation: true,
+    });
+
+    expect(process.exitCode).toBe(2);
+    const errors = ctx.errSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(errors).toContain("Structure errors");
+  });
+});
+
+describe("lint --strict-state", () => {
+  let ctx: CliTestContext;
+  beforeEach(async () => {
+    ctx = await createCliTestContext("strict-lint-state");
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("promotes skipped steps to errors", async () => {
+    // Seed some tools so cache isn't empty (lint skips state validation on empty cache)
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: "toolshed.g2.bx.psu.edu/repos/nobody/fake/fake_tool",
+          tool_version: "1.0",
+          tool_state: {},
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "missing.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runLint(wfPath, { cacheDir: ctx.tmpDir, strictState: true });
+
+    expect(process.exitCode).toBe(2);
+  });
+});

--- a/packages/cli/test/strict-options.test.ts
+++ b/packages/cli/test/strict-options.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { resolveStrictOptions } from "../src/commands/strict-options.js";
+
+describe("resolveStrictOptions", () => {
+  it("--strict expands to all three", () => {
+    const result = resolveStrictOptions({ strict: true });
+    expect(result).toEqual({
+      strictStructure: true,
+      strictEncoding: true,
+      strictState: true,
+    });
+  });
+
+  it("individual flags work independently", () => {
+    expect(resolveStrictOptions({ strictStructure: true })).toEqual({
+      strictStructure: true,
+      strictEncoding: false,
+      strictState: false,
+    });
+    expect(resolveStrictOptions({ strictEncoding: true })).toEqual({
+      strictStructure: false,
+      strictEncoding: true,
+      strictState: false,
+    });
+    expect(resolveStrictOptions({ strictState: true })).toEqual({
+      strictStructure: false,
+      strictEncoding: false,
+      strictState: true,
+    });
+  });
+
+  it("empty options → all false", () => {
+    expect(resolveStrictOptions({})).toEqual({
+      strictStructure: false,
+      strictEncoding: false,
+      strictState: false,
+    });
+  });
+
+  it("individual flags compose with --strict", () => {
+    const result = resolveStrictOptions({ strict: true, strictStructure: false });
+    // --strict overrides individual false
+    expect(result.strictStructure).toBe(true);
+  });
+
+  it("two flags compose independently", () => {
+    const result = resolveStrictOptions({ strictStructure: true, strictState: true });
+    expect(result).toEqual({
+      strictStructure: true,
+      strictEncoding: false,
+      strictState: true,
+    });
+  });
+});

--- a/packages/cli/test/strict-validate.test.ts
+++ b/packages/cli/test/strict-validate.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as YAML from "yaml";
+
+import { runValidateWorkflow } from "../src/commands/validate-workflow.js";
+import { createCliTestContext, type CliTestContext } from "./helpers/cli-test-context.js";
+import { seedAllTools, SIMPLE_TOOL_ID } from "./helpers/fixtures.js";
+
+describe("validate --strict-encoding", () => {
+  let ctx: CliTestContext;
+
+  beforeEach(async () => {
+    ctx = await createCliTestContext("strict-enc");
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("rejects native workflow with JSON-string tool_state", async () => {
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          // tool_state as a JSON string = legacy encoding
+          tool_state: JSON.stringify({ input_text: "hello", num_lines: "5" }),
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "legacy.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictEncoding: true });
+
+    expect(process.exitCode).toBe(2);
+    const errors = ctx.errSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(errors).toContain("Encoding errors");
+  });
+
+  it("passes clean native workflow with dict tool_state", async () => {
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          tool_state: { input_text: "hello", num_lines: 5 },
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "clean.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictEncoding: true });
+
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("rejects format2 workflow using tool_state instead of state", async () => {
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      class: "GalaxyWorkflow",
+      inputs: [],
+      outputs: [],
+      steps: [
+        {
+          id: "step1",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          tool_state: { input_text: "hello", num_lines: 5 },
+          in: [],
+          out: [],
+        },
+      ],
+    };
+    const wfPath = join(ctx.tmpDir, "bad.gxwf.yml");
+    await writeFile(wfPath, YAML.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictEncoding: true });
+
+    expect(process.exitCode).toBe(2);
+  });
+});
+
+describe("validate --strict-structure", () => {
+  let ctx: CliTestContext;
+
+  beforeEach(async () => {
+    ctx = await createCliTestContext("strict-struct");
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("rejects native workflow with extra root keys", async () => {
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {},
+      bogus_key: "should fail",
+    };
+    const wfPath = join(ctx.tmpDir, "extra.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictStructure: true });
+
+    expect(process.exitCode).toBe(2);
+    const errors = ctx.errSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(errors).toContain("Structure errors");
+  });
+
+  it("passes clean native workflow", async () => {
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {},
+    };
+    const wfPath = join(ctx.tmpDir, "clean.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, {
+      cacheDir: ctx.tmpDir,
+      strictStructure: true,
+      toolState: false,
+    });
+
+    expect(process.exitCode).toBe(0);
+  });
+});
+
+describe("validate --strict-state", () => {
+  let ctx: CliTestContext;
+
+  beforeEach(async () => {
+    ctx = await createCliTestContext("strict-state");
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("promotes skipped (uncached tool) to failure", async () => {
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: "toolshed.g2.bx.psu.edu/repos/nobody/fake/fake_tool",
+          tool_version: "1.0",
+          tool_state: {},
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "missing.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictState: true });
+
+    expect(process.exitCode).toBe(2);
+    const errors = ctx.errSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(errors).toContain("skipped steps not allowed");
+  });
+
+  it("passes when all steps validate ok", async () => {
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          tool_state: { input_text: "hello", num_lines: 5 },
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "ok.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictState: true });
+
+    expect(process.exitCode).toBe(0);
+  });
+});
+
+describe("validate --strict (all three)", () => {
+  let ctx: CliTestContext;
+
+  beforeEach(async () => {
+    ctx = await createCliTestContext("strict-all");
+  });
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it("clean workflow passes with --strict", async () => {
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          tool_state: { input_text: "hello", num_lines: 5 },
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "clean.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strict: true });
+
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("encoding error caught with --strict", async () => {
+    await seedAllTools(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          tool_state: JSON.stringify({ input_text: "hello" }),
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "bad.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strict: true });
+
+    expect(process.exitCode).toBe(2);
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -107,6 +107,7 @@ export {
   /** Roundtrip a native workflow through format2 and back, diffing tool_state per step. */
   roundtripValidate,
   type RoundtripResult,
+  type RoundtripStrictOptions,
   type StepRoundtripResult,
   type StepDiff,
   type DiffSeverity,
@@ -135,4 +136,10 @@ export {
   /** Lint best practices for a native Galaxy workflow. */
   lintBestPracticesNative,
   type LintResult,
+  /** Strict encoding check — reject JSON-string tool_state (native) or tool_state field misuse (format2). */
+  validateEncodingNative,
+  validateEncodingFormat2,
+  checkStrictEncoding,
+  /** Strict structure check — reject unknown keys via onExcessProperty: "error". */
+  checkStrictStructure,
 } from "./workflow/index.js";

--- a/packages/schema/src/workflow/index.ts
+++ b/packages/schema/src/workflow/index.ts
@@ -111,6 +111,7 @@ export {
 export {
   roundtripValidate,
   type RoundtripResult,
+  type RoundtripStrictOptions,
   type StepRoundtripResult,
   type StepDiff,
   type DiffSeverity,
@@ -121,6 +122,13 @@ export {
 export { cleanWorkflow } from "./clean.js";
 
 export { detectFormat, type WorkflowFormat } from "./detect-format.js";
+
+export {
+  validateEncodingNative,
+  validateEncodingFormat2,
+  checkStrictEncoding,
+  checkStrictStructure,
+} from "./strict-checks.js";
 
 export {
   LintContext,

--- a/packages/schema/src/workflow/roundtrip.ts
+++ b/packages/schema/src/workflow/roundtrip.ts
@@ -18,6 +18,7 @@ import type { StatefulExportResult } from "./normalized/toFormat2Stateful.js";
 import { isConnectedValue, isRuntimeValue } from "./runtime-markers.js";
 import { STALE_KEYS as SKIP_KEYS, isRuntimeLeakKey } from "./stale-keys.js";
 import { stripStaleKeysToolAware } from "./clean.js";
+import { checkStrictEncoding, checkStrictStructure } from "./strict-checks.js";
 
 // --- Types ---
 
@@ -77,6 +78,17 @@ export interface RoundtripResult {
   success: boolean;
   /** No diffs at all (clean roundtrip). */
   clean: boolean;
+  /** Strict-encoding errors across all stages (input, forward output, reverse output). */
+  encodingErrors: string[];
+  /** Strict-structure errors across all stages (input, forward output, reverse output). */
+  structureErrors: string[];
+}
+
+/** Options controlling strict validation within roundtripValidate. */
+export interface RoundtripStrictOptions {
+  strictEncoding?: boolean;
+  strictStructure?: boolean;
+  strictState?: boolean;
 }
 
 // --- Bookkeeping / internal helpers ---
@@ -436,7 +448,21 @@ function collectSteps(
 export function roundtripValidate(
   nativeRaw: unknown,
   toolInputsResolver: ToolInputsResolver,
+  strictOpts?: RoundtripStrictOptions,
 ): RoundtripResult {
+  const strict = strictOpts ?? {};
+  const encodingErrors: string[] = [];
+  const structureErrors: string[] = [];
+
+  // Stage 1: strict checks on raw native input
+  const rawDict = nativeRaw as Record<string, unknown>;
+  if (strict.strictEncoding) {
+    encodingErrors.push(...checkStrictEncoding(rawDict, "native").map((e) => `input: ${e}`));
+  }
+  if (strict.strictStructure) {
+    structureErrors.push(...checkStrictStructure(rawDict, "native").map((e) => `input: ${e}`));
+  }
+
   const original = ensureNative(nativeRaw);
   const { tools: originalSteps, subworkflows: originalSubworkflows } = collectSteps(original);
 
@@ -495,9 +521,27 @@ export function roundtripValidate(
       reverseSteps,
       success: false,
       clean: false,
+      encodingErrors,
+      structureErrors,
     };
   }
   forwardSteps = forward.steps;
+
+  // Stage 2: strict checks on forward (format2) output
+  if (strict.strictEncoding) {
+    encodingErrors.push(
+      ...checkStrictEncoding(forward.workflow as Record<string, unknown>, "format2").map(
+        (e) => `forward: ${e}`,
+      ),
+    );
+  }
+  if (strict.strictStructure) {
+    structureErrors.push(
+      ...checkStrictStructure(forward.workflow as Record<string, unknown>, "format2").map(
+        (e) => `forward: ${e}`,
+      ),
+    );
+  }
 
   // Reverse: format2 → native
   try {
@@ -523,7 +567,25 @@ export function roundtripValidate(
       reverseSteps,
       success: false,
       clean: false,
+      encodingErrors,
+      structureErrors,
     };
+  }
+
+  // Stage 3: strict checks on reverse (reimported native) output
+  if (strict.strictEncoding) {
+    encodingErrors.push(
+      ...checkStrictEncoding(reimported as unknown as Record<string, unknown>, "native").map(
+        (e) => `reverse: ${e}`,
+      ),
+    );
+  }
+  if (strict.strictStructure) {
+    structureErrors.push(
+      ...checkStrictStructure(reimported as unknown as Record<string, unknown>, "native").map(
+        (e) => `reverse: ${e}`,
+      ),
+    );
   }
 
   const { tools: reimportedSteps } = collectSteps(reimported);
@@ -597,12 +659,15 @@ export function roundtripValidate(
   const toolResults = stepResults.filter((s) => s.failureClass !== "subworkflow_external_ref");
   const anyError = toolResults.some((s) => !s.success);
   const anyDiff = toolResults.some((s) => s.diffs.length > 0);
+  const hasStrictErrors = encodingErrors.length > 0 || structureErrors.length > 0;
   return {
     workflowName: (original.name ?? undefined) || undefined,
     stepResults,
     forwardSteps,
     reverseSteps,
-    success: !anyError,
-    clean: !anyDiff && !anyError,
+    success: !anyError && !hasStrictErrors,
+    clean: !anyDiff && !anyError && !hasStrictErrors,
+    encodingErrors,
+    structureErrors,
   };
 }

--- a/packages/schema/src/workflow/strict-checks.ts
+++ b/packages/schema/src/workflow/strict-checks.ts
@@ -1,0 +1,113 @@
+/**
+ * Pre-normalization strict validation checks for workflows.
+ *
+ * These run on raw workflow dicts before any schema normalization,
+ * matching the Python pattern of failing fast before decoding.
+ */
+import { NativeGalaxyWorkflowSchema, GalaxyWorkflowSchema } from "./raw/index.js";
+import type { WorkflowFormat } from "./detect-format.js";
+import { detectFormat } from "./detect-format.js";
+import * as ParseResult from "effect/ParseResult";
+import * as S from "effect/Schema";
+
+// ── Encoding checks ──────────────────────────────────────────────────
+
+/**
+ * Native: reject tool_state that is a JSON string instead of a parsed dict.
+ * Walks top-level steps only (matching Python `validate_encoding_native`).
+ */
+export function validateEncodingNative(workflowDict: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  const steps = workflowDict.steps;
+  if (!steps || typeof steps !== "object") return errors;
+
+  const entries: [string, unknown][] = Array.isArray(steps)
+    ? steps.map((s, i) => [String(i), s])
+    : Object.entries(steps as Record<string, unknown>);
+
+  for (const [key, step] of entries) {
+    if (!step || typeof step !== "object") continue;
+    const s = step as Record<string, unknown>;
+    if (s.type === "subworkflow") continue;
+    if (!s.tool_id) continue;
+
+    const toolState = s.tool_state;
+    if (typeof toolState === "string") {
+      errors.push(`step ${key}: tool_state is a JSON string (legacy encoding), expected a dict`);
+    }
+  }
+  return errors;
+}
+
+/**
+ * Format2: reject steps using `tool_state` field instead of `state`.
+ *
+ * No string-state check — format2 state comes from YAML parsing so
+ * it's always a dict. The Python side checks this defensively but
+ * it's not a real-world scenario.
+ */
+export function validateEncodingFormat2(workflowDict: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  const steps = workflowDict.steps;
+  if (!steps || !Array.isArray(steps)) return errors;
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    if (!step || typeof step !== "object") continue;
+    const s = step as Record<string, unknown>;
+    if (s.run && typeof s.run === "object") continue; // subworkflow
+    if (!s.tool_id) continue;
+
+    if ("tool_state" in s && !("state" in s)) {
+      errors.push(`step ${i}: uses "tool_state" instead of "state" (format2 should use "state")`);
+    }
+  }
+  return errors;
+}
+
+/** Dispatch encoding check based on format auto-detection. */
+export function checkStrictEncoding(
+  workflowDict: Record<string, unknown>,
+  format?: WorkflowFormat,
+): string[] {
+  const fmt = format ?? detectFormat(workflowDict);
+  return fmt === "native"
+    ? validateEncodingNative(workflowDict)
+    : validateEncodingFormat2(workflowDict);
+}
+
+// ── Structure checks ─────────────────────────────────────────────────
+
+function formatIssues(error: ParseResult.ParseError): string[] {
+  const issues = ParseResult.ArrayFormatter.formatErrorSync(error);
+  return issues.map((i) => `${i.path.join(".")}: ${i.message}`);
+}
+
+/**
+ * Strict structure check — decode with onExcessProperty: "error" to
+ * catch unknown keys at envelope and step level.
+ */
+export function checkStrictStructure(
+  workflowDict: Record<string, unknown>,
+  format?: WorkflowFormat,
+): string[] {
+  const fmt = format ?? detectFormat(workflowDict);
+
+  // Ensure class field is present for schema decoding
+  const data = { ...workflowDict };
+  if (fmt === "native" && !("class" in data)) {
+    data.class = "NativeGalaxyWorkflow";
+  } else if (fmt === "format2" && !("class" in data)) {
+    data.class = "GalaxyWorkflow";
+  }
+
+  const schema: S.Schema<any> =
+    fmt === "native" ? NativeGalaxyWorkflowSchema : GalaxyWorkflowSchema;
+  const decode = S.decodeUnknownEither(schema, { onExcessProperty: "error" });
+  const result = decode(data);
+
+  if (result._tag === "Left") {
+    return formatIssues(result.left);
+  }
+  return [];
+}

--- a/packages/schema/test/strict-checks.test.ts
+++ b/packages/schema/test/strict-checks.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateEncodingNative,
+  validateEncodingFormat2,
+  checkStrictEncoding,
+  checkStrictStructure,
+} from "../src/workflow/strict-checks.js";
+
+describe("validateEncodingNative", () => {
+  it("clean native workflow → no errors", () => {
+    const wf = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: "some_tool",
+          tool_state: { input_text: "hello" },
+        },
+      },
+    };
+    expect(validateEncodingNative(wf)).toEqual([]);
+  });
+
+  it("tool_state as JSON string → error", () => {
+    const wf = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: "some_tool",
+          tool_state: JSON.stringify({ input_text: "hello" }),
+        },
+      },
+    };
+    const errors = validateEncodingNative(wf);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("step 0");
+    expect(errors[0]).toContain("JSON string");
+  });
+
+  it("skips subworkflow steps", () => {
+    const wf = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "subworkflow",
+          tool_state: "ignored",
+        },
+      },
+    };
+    expect(validateEncodingNative(wf)).toEqual([]);
+  });
+
+  it("skips steps without tool_id", () => {
+    const wf = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "data_input",
+          tool_id: null,
+          tool_state: "{}",
+        },
+      },
+    };
+    expect(validateEncodingNative(wf)).toEqual([]);
+  });
+});
+
+describe("validateEncodingFormat2", () => {
+  it("clean format2 workflow → no errors", () => {
+    const wf = {
+      class: "GalaxyWorkflow",
+      steps: [
+        {
+          tool_id: "some_tool",
+          state: { input_text: "hello" },
+        },
+      ],
+    };
+    expect(validateEncodingFormat2(wf)).toEqual([]);
+  });
+
+  it("tool_state instead of state → error", () => {
+    const wf = {
+      class: "GalaxyWorkflow",
+      steps: [
+        {
+          tool_id: "some_tool",
+          tool_state: { input_text: "hello" },
+        },
+      ],
+    };
+    const errors = validateEncodingFormat2(wf);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("step 0");
+    expect(errors[0]).toContain("tool_state");
+    expect(errors[0]).toContain("state");
+  });
+
+  it("step with both state and tool_state → no error (state present)", () => {
+    const wf = {
+      class: "GalaxyWorkflow",
+      steps: [
+        {
+          tool_id: "some_tool",
+          state: { input_text: "hello" },
+          tool_state: { input_text: "hello" },
+        },
+      ],
+    };
+    expect(validateEncodingFormat2(wf)).toEqual([]);
+  });
+
+  it("skips subworkflow steps (run field)", () => {
+    const wf = {
+      class: "GalaxyWorkflow",
+      steps: [
+        {
+          run: { class: "GalaxyWorkflow", steps: [] },
+          tool_state: { input_text: "hello" },
+        },
+      ],
+    };
+    expect(validateEncodingFormat2(wf)).toEqual([]);
+  });
+});
+
+describe("checkStrictEncoding", () => {
+  it("dispatches to native for native workflows", () => {
+    const wf = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: "t",
+          tool_state: '{"x": 1}',
+        },
+      },
+    };
+    expect(checkStrictEncoding(wf)).toHaveLength(1);
+  });
+
+  it("dispatches to format2 for format2 workflows", () => {
+    const wf = {
+      class: "GalaxyWorkflow",
+      steps: [{ tool_id: "t", tool_state: { x: 1 } }],
+    };
+    expect(checkStrictEncoding(wf)).toHaveLength(1);
+  });
+});
+
+describe("checkStrictStructure", () => {
+  it("clean native workflow → no errors", () => {
+    const wf = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {},
+    };
+    expect(checkStrictStructure(wf, "native")).toEqual([]);
+  });
+
+  it("native workflow with extra root key → errors", () => {
+    const wf = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {},
+      bogus_extra_key: "should fail",
+    };
+    const errors = checkStrictStructure(wf, "native");
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("clean format2 workflow → no errors", () => {
+    const wf = {
+      class: "GalaxyWorkflow",
+      inputs: [],
+      outputs: [],
+      steps: [],
+    };
+    expect(checkStrictStructure(wf, "format2")).toEqual([]);
+  });
+
+  it("format2 workflow with extra key → errors", () => {
+    const wf = {
+      class: "GalaxyWorkflow",
+      inputs: [],
+      outputs: [],
+      steps: [],
+      bogus_extra_key: "should fail",
+    };
+    const errors = checkStrictStructure(wf, "format2");
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add three granular strict validation flags (`--strict-structure`, `--strict-encoding`, `--strict-state`) to all `gxwf` commands (validate, lint, convert, roundtrip + tree variants). `--strict` remains as shorthand for all three.
- New `strict-checks.ts` in schema package with `checkStrictEncoding`/`checkStrictStructure` validators
- `RoundtripResult` enriched with `encodingErrors`/`structureErrors` arrays and multi-stage validation (input, forward output, reverse output)
- `StepValidationResult` gains `skippedReason` field for structured JSON output consumers
- IWC sweep test suites for strict-encoding, strict-structure, and combined strict validation

Mirrors Galaxy Python commit `509988c80b0cc64c86054074c1660326c18fdc5c` on `wf_tool_state`.

## Test plan

- [x] 14 unit tests for encoding/structure validators (`strict-checks.test.ts`)
- [x] 5 unit tests for option expansion/composition (`strict-options.test.ts`)
- [x] 9 behavioral tests for validate with strict flags (`strict-validate.test.ts`)
- [x] 3 behavioral tests for lint with strict flags (`strict-lint.test.ts`)
- [x] 3 IWC sweep suites (gated on `GALAXY_TEST_IWC_DIRECTORY`)
- [x] All 4714 existing tests pass, lint/format/typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)