### PR TITLE
Extend cleanWorkflow() — structural + tool-aware cleaning, --skip-uuid

### DIFF
--- a/.changeset/clean-workflow-structural-tool-aware.md
+++ b/.changeset/clean-workflow-structural-tool-aware.md
@@ -1,0 +1,12 @@
+---
+"@galaxy-tool-util/schema": minor
+"@galaxy-tool-util/cli": patch
+---
+
+Extend `cleanWorkflow()` with structural cleaning and tool-aware stale key removal.
+
+- `cleanWorkflow()` now strips Galaxy-injected `uuid` and `errors` from both native and format2 workflow/step dicts (not `position`, which is a legitimate workflow property)
+- Format2 workflows now return per-step `CleanStepResult[]` instead of an empty array
+- New optional `toolInputsResolver` option: when provided, drops keys not in the tool's parameter tree via `stripStaleKeysToolAware` (native) or `walkFormat2State` (format2) — steps whose tool is not found in the resolver are skipped gracefully
+- `cleanWorkflow()` signature is now `async` (returns `Promise<CleanWorkflowResult>`) — **breaking change** for callers that used the result synchronously
+- New export: `CleanWorkflowOptions`

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,9 @@ endif
 	mkdir -p $(WFSTATE_DST)/fixtures
 	cp $(WFSTATE_SRC)/fixtures/synthetic-cat1-clean.ga $(WFSTATE_DST)/fixtures/
 	cp $(WFSTATE_SRC)/fixtures/synthetic-cat1-stale.ga $(WFSTATE_DST)/fixtures/
+	cp $(WFSTATE_SRC)/fixtures/synthetic-cat1-errors.ga $(WFSTATE_DST)/fixtures/
 	cp $(WFSTATE_SRC)/fixtures/synthetic-cat1.gxwf.yml $(WFSTATE_DST)/fixtures/
+	cp $(WFSTATE_SRC)/fixtures/synthetic-cat1-stale.gxwf.yml $(WFSTATE_DST)/fixtures/
 	cp $(WFSTATE_IWC_SRC)/RepeatMasking-Workflow.ga $(WFSTATE_DST)/fixtures/
 	cp $(WFSTATE_IWC_SRC)/rnaseq-sr.ga $(WFSTATE_DST)/fixtures/
 	cp $(WFSTATE_FWDATA_SRC)/test_workflow_1.ga $(WFSTATE_DST)/fixtures/
@@ -230,7 +232,7 @@ ifndef GALAXY_ROOT
 endif
 	@echo "Checking workflow_state fixtures..."
 	@ok=true; \
-	for f in synthetic-cat1-clean.ga synthetic-cat1-stale.ga synthetic-cat1.gxwf.yml; do \
+	for f in synthetic-cat1-clean.ga synthetic-cat1-stale.ga synthetic-cat1-errors.ga synthetic-cat1.gxwf.yml synthetic-cat1-stale.gxwf.yml; do \
 		src=$(WFSTATE_SRC)/fixtures/$$f; \
 		local=$(WFSTATE_DST)/fixtures/$$f; \
 		if [ -f "$$local" ] && ! diff -q "$$src" "$$local" >/dev/null 2>&1; then \

--- a/packages/cli/src/bin/gxwf.ts
+++ b/packages/cli/src/bin/gxwf.ts
@@ -46,6 +46,7 @@ program
   .option("--format <fmt>", "Force format: native or format2 (auto-detected by default)")
   .option("--json", "Output structured JSON report")
   .option("--report-html [file]", "Write HTML report to file (or stdout if omitted)")
+  .option("--skip-uuid", "Skip stripping uuid fields (errors are always stripped)")
   .action(runClean);
 
 addStrictOptions(
@@ -132,6 +133,7 @@ program
   .option("--json", "Output structured JSON report")
   .option("--report-markdown [file]", "Write Markdown report to file (or stdout if omitted)")
   .option("--report-html [file]", "Write HTML report to file (or stdout if omitted)")
+  .option("--skip-uuid", "Skip stripping uuid fields (errors are always stripped)")
   .action(runCleanTree);
 
 addStrictOptions(

--- a/packages/cli/src/commands/clean-tree.ts
+++ b/packages/cli/src/commands/clean-tree.ts
@@ -3,6 +3,7 @@
  */
 import {
   cleanWorkflow,
+  type CleanWorkflowOptions,
   type WorkflowCleanResult,
   type TreeCleanReport,
   buildWorkflowCleanResult,
@@ -18,6 +19,7 @@ export interface CleanTreeOptions extends ReportOutputOptions {
   outputDir?: string;
   format?: string;
   json?: boolean;
+  skipUuid?: boolean;
 }
 
 export async function runCleanTree(dir: string, opts: CleanTreeOptions): Promise<void> {
@@ -25,7 +27,8 @@ export async function runCleanTree(dir: string, opts: CleanTreeOptions): Promise
 
   const treeResult = await collectTree<WorkflowCleanResult>(dir, async (info, data) => {
     const format = resolveFormat(data, opts.format);
-    const { results: stepResults } = cleanWorkflow(data);
+    const cleanOpts: CleanWorkflowOptions = { skipUuid: opts.skipUuid };
+    const { results: stepResults } = await cleanWorkflow(data, cleanOpts);
 
     if (outputDir) {
       const outPath = join(outputDir, info.relativePath);

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -1,7 +1,11 @@
 /**
  * `gxwf clean` — strip stale keys and decode legacy tool_state encoding.
  */
-import { cleanWorkflow, buildSingleCleanReport } from "@galaxy-tool-util/schema";
+import {
+  cleanWorkflow,
+  buildSingleCleanReport,
+  type CleanWorkflowOptions,
+} from "@galaxy-tool-util/schema";
 import {
   readWorkflowFile,
   resolveFormat,
@@ -16,6 +20,7 @@ export interface CleanOptions {
   format?: string;
   json?: boolean;
   reportHtml?: string | boolean;
+  skipUuid?: boolean;
 }
 
 export async function runClean(filePath: string, opts: CleanOptions): Promise<void> {
@@ -25,7 +30,8 @@ export async function runClean(filePath: string, opts: CleanOptions): Promise<vo
   const format = resolveFormat(data, opts.format);
   const before = opts.diff ? JSON.stringify(data, null, 2) : null;
 
-  const { results } = cleanWorkflow(data);
+  const cleanOpts: CleanWorkflowOptions = { skipUuid: opts.skipUuid };
+  const { results } = await cleanWorkflow(data, cleanOpts);
 
   if (opts.json || opts.reportHtml) {
     const report = buildSingleCleanReport(filePath, results);

--- a/packages/gxwf-web/src/router.ts
+++ b/packages/gxwf-web/src/router.ts
@@ -333,7 +333,7 @@ export function createRequestHandler(state: AppState) {
                 preserve: route.query.getAll("preserve"),
                 strip: route.query.getAll("strip"),
               };
-              result = operateClean(wf, copts);
+              result = await operateClean(wf, copts);
               break;
             }
             case "to-format2":

--- a/packages/gxwf-web/src/workflows.ts
+++ b/packages/gxwf-web/src/workflows.ts
@@ -322,9 +322,12 @@ export interface CleanOptions {
 }
 
 /** Report stale keys in a workflow (no tool cache needed). */
-export function operateClean(wf: WorkflowFile, _opts: CleanOptions = {}): SingleCleanReport {
+export async function operateClean(
+  wf: WorkflowFile,
+  _opts: CleanOptions = {},
+): Promise<SingleCleanReport> {
   const { absPath, data } = wf;
-  const { results } = cleanWorkflow(data);
+  const { results } = await cleanWorkflow(data);
   return buildSingleCleanReport(absPath, results);
 }
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -238,6 +238,7 @@ export {
   buildWorkflowToNativeResult,
   buildToNativeTreeReport,
   buildRoundTripTreeReport,
+  type CleanWorkflowOptions,
 } from "./workflow/index.js";
 
 export { ToolStateValidator, type ToolStateDiagnostic } from "./tool-state-validator.js";

--- a/packages/schema/src/workflow/clean.ts
+++ b/packages/schema/src/workflow/clean.ts
@@ -5,6 +5,9 @@
  * (__page__, __rerun_remap_job_id__), runtime leak keys (chromInfo, __input_ext),
  * and decodes JSON-encoded tool_state strings into proper dicts.
  *
+ * Also strips Galaxy-injected structural properties (`uuid`, `errors`) from both
+ * native and format2 workflow and step dicts.
+ *
  * Also provides a tool-definition-aware strip (`stripStaleKeysToolAware`)
  * that mirrors Galaxy's `clean._strip_recursive`: uses the declared
  * parameter tree to drop any undeclared key (runtime leaks, stale-branch
@@ -16,7 +19,8 @@ import type { ToolParameterModel } from "../schema/bundle-types.js";
 import type { CleanStepResult } from "./report-models.js";
 import { cleanDisplayLabel } from "./report-models.js";
 import { detectFormat } from "./detect-format.js";
-import { walkNativeState, SKIP_VALUE } from "./walker.js";
+import { walkNativeState, walkFormat2State, SKIP_VALUE } from "./walker.js";
+import type { ToolInputsResolver } from "./normalized/stateful-runner.js";
 
 /** Keys injected by Galaxy's tool form machinery — never meaningful in saved workflows. */
 const BOOKKEEPING_KEYS = new Set(["__page__", "__rerun_remap_job_id__"]);
@@ -28,6 +32,19 @@ const RUNTIME_LEAK_KEYS = new Set(["chromInfo", "__input_ext"]);
 const INTERNAL_KEYS = new Set(["__current_case__", "__index__"]);
 
 const STALE_KEYS = new Set([...BOOKKEEPING_KEYS, ...RUNTIME_LEAK_KEYS, ...INTERNAL_KEYS]);
+
+/**
+ * Galaxy-injected structural properties — present on workflow and step dicts
+ * in both native and format2 exports, but not meaningful in saved/shared
+ * workflows. Stripped from workflow-level and step-level dicts.
+ *
+ * `position` is intentionally excluded — it is a legitimate workflow property
+ * that VS Code and other tools may use.
+ *
+ * `errors` is always stripped. `uuid` is stripped by default but can be
+ * suppressed with `CleanWorkflowOptions.skipUuid`.
+ */
+const ALWAYS_STRIP_STEP_KEYS = new Set(["errors"]);
 
 /**
  * Decode a legacy JSON-encoded tool_state value. If the value is a string
@@ -112,17 +129,44 @@ function stripStaleValue(value: unknown): unknown {
   return value;
 }
 
+/**
+ * Strip Galaxy-injected structural properties from a step dict in-place.
+ * Always removes `errors`; removes `uuid` unless `skipUuid` is true.
+ * Returns the list of keys actually removed.
+ */
+function stripStructuralStep(stepDict: Record<string, unknown>, skipUuid: boolean): string[] {
+  const removed: string[] = [];
+  for (const key of ALWAYS_STRIP_STEP_KEYS) {
+    if (key in stepDict) {
+      delete stepDict[key];
+      removed.push(key);
+    }
+  }
+  if (!skipUuid && "uuid" in stepDict) {
+    delete stepDict.uuid;
+    removed.push("uuid");
+  }
+  return removed;
+}
+
 /** Clean a single native step's tool_state in place, returning step result info. */
-function cleanNativeStep(stepDef: Record<string, unknown>, stepLabel: string): CleanStepResult {
+async function cleanNativeStep(
+  stepDef: Record<string, unknown>,
+  stepLabel: string,
+  opts: CleanWorkflowOptions,
+): Promise<CleanStepResult> {
   const toolId = (stepDef.tool_id as string) ?? null;
   const toolVersion = (stepDef.tool_version as string) ?? null;
+
+  // Strip structural properties from the step dict itself (uuid, errors)
+  const removedKeys: string[] = stripStructuralStep(stepDef, opts.skipUuid ?? false);
 
   if (!toolId) {
     return {
       step: stepLabel,
       tool_id: null,
       version: null,
-      removed_keys: [],
+      removed_keys: removedKeys,
       skipped: true,
       skip_reason: "no tool_id",
       display_label: cleanDisplayLabel(null, null),
@@ -135,7 +179,7 @@ function cleanNativeStep(stepDef: Record<string, unknown>, stepLabel: string): C
       step: stepLabel,
       tool_id: toolId,
       version: toolVersion,
-      removed_keys: [],
+      removed_keys: removedKeys,
       skipped: true,
       skip_reason: "no tool_state",
       display_label: cleanDisplayLabel(toolId, toolVersion),
@@ -148,15 +192,25 @@ function cleanNativeStep(stepDef: Record<string, unknown>, stepLabel: string): C
       step: stepLabel,
       tool_id: toolId,
       version: toolVersion,
-      removed_keys: [],
+      removed_keys: removedKeys,
       skipped: true,
       skip_reason: "unparseable tool_state",
       display_label: cleanDisplayLabel(toolId, toolVersion),
     };
   }
 
-  const removedKeys: string[] = [];
-  stepDef.tool_state = stripStaleKeys(parsed, removedKeys);
+  let cleaned = stripStaleKeys(parsed, removedKeys);
+
+  // Tool-aware strip: drop keys not in the tool's parameter tree
+  if (opts.toolInputsResolver) {
+    const inputs = opts.toolInputsResolver(toolId, toolVersion);
+    if (inputs) {
+      const inputConnections = (stepDef.input_connections ?? {}) as Record<string, unknown>;
+      cleaned = stripStaleKeysToolAware(cleaned, inputs, inputConnections);
+    }
+  }
+
+  stepDef.tool_state = cleaned;
 
   return {
     step: stepLabel,
@@ -170,7 +224,11 @@ function cleanNativeStep(stepDef: Record<string, unknown>, stepLabel: string): C
 }
 
 /** Recursively clean all steps in a native workflow dict. */
-function cleanNativeSteps(workflowDict: Record<string, unknown>, prefix = ""): CleanStepResult[] {
+async function cleanNativeSteps(
+  workflowDict: Record<string, unknown>,
+  opts: CleanWorkflowOptions,
+  prefix = "",
+): Promise<CleanStepResult[]> {
   const steps = workflowDict.steps as Record<string, Record<string, unknown>> | undefined;
   if (!steps) return [];
   const results: CleanStepResult[] = [];
@@ -179,11 +237,15 @@ function cleanNativeSteps(workflowDict: Record<string, unknown>, prefix = ""): C
     const stepLabel = prefix ? `${prefix}${key}` : key;
     if (stepDef.type === "subworkflow" && stepDef.subworkflow) {
       results.push(
-        ...cleanNativeSteps(stepDef.subworkflow as Record<string, unknown>, `${stepLabel}.`),
+        ...(await cleanNativeSteps(
+          stepDef.subworkflow as Record<string, unknown>,
+          opts,
+          `${stepLabel}.`,
+        )),
       );
       continue;
     }
-    results.push(cleanNativeStep(stepDef, stepLabel));
+    results.push(await cleanNativeStep(stepDef, stepLabel, opts));
   }
   return results;
 }
@@ -217,20 +279,131 @@ export function stripStaleKeysToolAware(
   );
 }
 
+/**
+ * Strip all keys from a format2 step's `state` that are not declared in
+ * the tool's parameter tree. Format2 analogue of `stripStaleKeysToolAware`.
+ */
+function stripStaleKeysToolAwareFormat2(
+  state: Record<string, unknown>,
+  toolInputs: ToolParameterModel[],
+): Record<string, unknown> {
+  return walkFormat2State(toolInputs, state, (_input, value) =>
+    value === undefined ? SKIP_VALUE : value,
+  );
+}
+
+/** Clean a single format2 step dict in place, returning step result info. */
+async function cleanFormat2Step(
+  stepDef: Record<string, unknown>,
+  stepLabel: string,
+  opts: CleanWorkflowOptions,
+): Promise<CleanStepResult> {
+  const toolId = (stepDef.tool_id as string | null | undefined) ?? null;
+  const toolVersion = (stepDef.tool_version as string | null | undefined) ?? null;
+
+  const removedKeys: string[] = stripStructuralStep(stepDef, opts.skipUuid ?? false);
+
+  // Tool-aware strip on `state` field
+  if (opts.toolInputsResolver && toolId) {
+    const inputs = opts.toolInputsResolver(toolId, toolVersion);
+    if (inputs) {
+      if (stepDef.state && typeof stepDef.state === "object" && !Array.isArray(stepDef.state)) {
+        stepDef.state = stripStaleKeysToolAwareFormat2(
+          stepDef.state as Record<string, unknown>,
+          inputs,
+        );
+      }
+      if (
+        stepDef.tool_state &&
+        typeof stepDef.tool_state === "object" &&
+        !Array.isArray(stepDef.tool_state)
+      ) {
+        stepDef.tool_state = stripStaleKeysToolAwareFormat2(
+          stepDef.tool_state as Record<string, unknown>,
+          inputs,
+        );
+      }
+    }
+  }
+
+  return {
+    step: stepLabel,
+    tool_id: toolId,
+    version: toolVersion,
+    removed_keys: removedKeys,
+    skipped: false,
+    skip_reason: "",
+    display_label: cleanDisplayLabel(toolId, toolVersion),
+  };
+}
+
+/** Clean all steps in a format2 workflow dict. Steps may be a list or a dict. */
+async function cleanFormat2Steps(
+  workflowDict: Record<string, unknown>,
+  opts: CleanWorkflowOptions,
+): Promise<CleanStepResult[]> {
+  const rawSteps = workflowDict.steps;
+  if (!rawSteps) return [];
+
+  const results: CleanStepResult[] = [];
+
+  if (Array.isArray(rawSteps)) {
+    for (let i = 0; i < rawSteps.length; i++) {
+      const stepDef = rawSteps[i] as Record<string, unknown>;
+      const label =
+        (stepDef.label as string | undefined) ?? (stepDef.id as string | undefined) ?? String(i);
+      results.push(await cleanFormat2Step(stepDef, label, opts));
+    }
+  } else if (rawSteps !== null && typeof rawSteps === "object") {
+    for (const [key, stepDef] of Object.entries(rawSteps as Record<string, unknown>)) {
+      const step = stepDef as Record<string, unknown>;
+      const label = (step.label as string | undefined) ?? (step.id as string | undefined) ?? key;
+      results.push(await cleanFormat2Step(step, label, opts));
+    }
+  }
+
+  return results;
+}
+
+export interface CleanWorkflowOptions {
+  toolInputsResolver?: ToolInputsResolver;
+  /**
+   * When true, skip stripping `uuid` from workflow and step dicts.
+   * Defaults to false (strip uuid).
+   */
+  skipUuid?: boolean;
+}
+
 export interface CleanWorkflowResult {
   workflow: Record<string, unknown>;
   results: CleanStepResult[];
 }
 
 /**
- * Clean a workflow — strip stale keys and decode legacy tool_state encoding.
- * Mutates the workflow dict in place. Format2 workflows pass through unchanged.
+ * Clean a workflow — strip structural properties (`uuid`, `errors`), stale
+ * tool_state bookkeeping keys, and decode legacy tool_state encoding.
+ *
+ * Mutates the workflow dict in place. Handles both native and format2 formats.
  * Returns both the mutated workflow and per-step clean results.
+ *
+ * When `opts.toolInputsResolver` is provided, also performs tool-aware stale
+ * key removal: drops any `tool_state` / `state` keys not declared in the
+ * tool's parameter tree (native via `stripStaleKeysToolAware`, format2 via
+ * `walkFormat2State`). Steps whose tool is not found in the resolver are
+ * left unchanged.
  */
-export function cleanWorkflow(workflowDict: Record<string, unknown>): CleanWorkflowResult {
+export async function cleanWorkflow(
+  workflowDict: Record<string, unknown>,
+  opts: CleanWorkflowOptions = {},
+): Promise<CleanWorkflowResult> {
+  // Strip workflow-level uuid from both formats
+  if (!opts.skipUuid) delete workflowDict.uuid;
+
   if (detectFormat(workflowDict) === "format2") {
-    return { workflow: workflowDict, results: [] };
+    const results = await cleanFormat2Steps(workflowDict, opts);
+    return { workflow: workflowDict, results };
   }
-  const results = cleanNativeSteps(workflowDict);
+
+  const results = await cleanNativeSteps(workflowDict, opts);
   return { workflow: workflowDict, results };
 }

--- a/packages/schema/src/workflow/index.ts
+++ b/packages/schema/src/workflow/index.ts
@@ -121,7 +121,7 @@ export {
   type RoundtripFailureClass,
 } from "./roundtrip.js";
 
-export { cleanWorkflow, type CleanWorkflowResult } from "./clean.js";
+export { cleanWorkflow, type CleanWorkflowOptions, type CleanWorkflowResult } from "./clean.js";
 
 export { detectFormat, type WorkflowFormat } from "./detect-format.js";
 

--- a/packages/schema/src/workflow/walker.ts
+++ b/packages/schema/src/workflow/walker.ts
@@ -120,7 +120,8 @@ export function walkNativeState(
         instances.push(instanceResult);
       }
 
-      if (instances.length > 0) {
+      // Preserve explicit empty arrays (valid state); omit only when key is absent
+      if (name in state || instances.length > 0) {
         result[name] = instances;
       }
     } else if (parameterType === "gx_section") {
@@ -231,7 +232,8 @@ export function walkFormat2State(
         instances.push(instanceResult);
       }
 
-      if (instances.length > 0) {
+      // Preserve explicit empty arrays (valid state); omit only when key is absent
+      if (name in state || instances.length > 0) {
         result[name] = instances;
       }
     } else if (parameterType === "gx_section") {

--- a/packages/schema/test/clean.test.ts
+++ b/packages/schema/test/clean.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for cleanWorkflow() — structural cleaning + tool-aware stale key removal.
+ *
+ * Red-to-green: tests written before the implementation is complete.
+ */
+
+import { describe, it, expect } from "vitest";
+import { cleanWorkflow } from "../src/workflow/clean.js";
+import type { ToolInputsResolver } from "../src/workflow/normalized/stateful-runner.js";
+import type { ToolParameterModel, IntegerParameterModel } from "../src/schema/bundle-types.js";
+
+// --- Param factories ---
+
+function intParam(name: string): IntegerParameterModel {
+  return {
+    name,
+    parameter_type: "gx_integer",
+    type: "integer",
+    hidden: false,
+    label: null,
+    help: null,
+    argument: null,
+    is_dynamic: false,
+    optional: false,
+    value: 0,
+    min: null,
+    max: null,
+    validators: [],
+  };
+}
+
+function mapResolver(map: Record<string, ToolParameterModel[]>): ToolInputsResolver {
+  return (toolId) => map[toolId];
+}
+
+// --- Native workflow fixtures ---
+
+function nativeWorkflow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    a_galaxy_workflow: "true",
+    format_version: "0.1",
+    uuid: "wf-uuid-1234",
+    steps: {},
+    ...overrides,
+  };
+}
+
+function nativeStep(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "tool",
+    tool_id: "toolshed.g2.bx.psu.edu/repos/devteam/some_tool/some_tool/1.0",
+    tool_version: "1.0",
+    tool_state: { param_a: 42, param_b: "hello" },
+    uuid: "step-uuid-5678",
+    errors: "some runtime error",
+    ...overrides,
+  };
+}
+
+// --- Format2 workflow fixtures ---
+
+function format2Workflow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    class: "GalaxyWorkflow",
+    uuid: "wf-uuid-format2",
+    steps: [],
+    ...overrides,
+  };
+}
+
+function format2Step(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    tool_id: "toolshed.g2.bx.psu.edu/repos/devteam/some_tool/some_tool/1.0",
+    tool_version: "1.0",
+    label: "step1",
+    uuid: "step-uuid-format2",
+    errors: "some runtime error",
+    state: { param_a: 42, param_b: "hello" },
+    in: [],
+    out: [],
+    ...overrides,
+  };
+}
+
+// ─── Structural cleaning — native ─────────────────────────────────────────────
+
+describe("cleanWorkflow — native structural cleaning", () => {
+  it("strips uuid from native workflow dict", async () => {
+    const wf = nativeWorkflow({ steps: {} });
+    expect(wf.uuid).toBe("wf-uuid-1234");
+    await cleanWorkflow(wf);
+    expect(wf.uuid).toBeUndefined();
+  });
+
+  it("preserves tool_state on native step", async () => {
+    const step = nativeStep();
+    const wf = nativeWorkflow({ steps: { "0": step } });
+    await cleanWorkflow(wf);
+    expect((step.tool_state as Record<string, unknown>).param_a).toBe(42);
+  });
+
+  it("reports structural keys as removed in step result", async () => {
+    const step = nativeStep();
+    const wf = nativeWorkflow({ steps: { "0": step } });
+    const { results } = await cleanWorkflow(wf);
+    const r = results[0];
+    expect(r.removed_keys).toContain("uuid");
+    expect(r.removed_keys).toContain("errors");
+  });
+});
+
+// ─── Structural cleaning — format2 ───────────────────────────────────────────
+
+describe("cleanWorkflow — format2 structural cleaning", () => {
+  it("strips uuid from format2 workflow dict", async () => {
+    const wf = format2Workflow({ steps: [] });
+    expect(wf.uuid).toBe("wf-uuid-format2");
+    await cleanWorkflow(wf);
+    expect(wf.uuid).toBeUndefined();
+  });
+
+  it("strips uuid and errors from format2 step (list steps)", async () => {
+    const step = format2Step();
+    const wf = format2Workflow({ steps: [step] });
+    await cleanWorkflow(wf);
+    expect(step.uuid).toBeUndefined();
+    expect(step.errors).toBeUndefined();
+  });
+
+  it("strips uuid and errors from format2 step (dict steps)", async () => {
+    const step = format2Step();
+    const wf = format2Workflow({ steps: { "0": step } });
+    await cleanWorkflow(wf);
+    expect(step.uuid).toBeUndefined();
+    expect(step.errors).toBeUndefined();
+  });
+
+  it("preserves position on format2 step", async () => {
+    const step = format2Step({ position: { top: 100, left: 200 } });
+    const wf = format2Workflow({ steps: [step] });
+    await cleanWorkflow(wf);
+    expect(step.position).toEqual({ top: 100, left: 200 });
+  });
+
+  it("preserves state on format2 step", async () => {
+    const step = format2Step();
+    const wf = format2Workflow({ steps: [step] });
+    await cleanWorkflow(wf);
+    expect((step.state as Record<string, unknown>).param_a).toBe(42);
+  });
+
+  it("returns step results for format2", async () => {
+    const step = format2Step();
+    const wf = format2Workflow({ steps: [step] });
+    const { results } = await cleanWorkflow(wf);
+    expect(results.length).toBe(1);
+    expect(results[0].removed_keys).toContain("uuid");
+    expect(results[0].removed_keys).toContain("errors");
+  });
+});
+
+// ─── Tool-aware native cleaning ───────────────────────────────────────────────
+
+describe("cleanWorkflow — native tool-aware stale key removal", () => {
+  it("removes stale tool_state key when resolver provided", async () => {
+    const step = nativeStep({ tool_state: { param_a: 42, stale_key: "old" } });
+    const wf = nativeWorkflow({ steps: { "0": step } });
+    const resolver = mapResolver({
+      "toolshed.g2.bx.psu.edu/repos/devteam/some_tool/some_tool/1.0": [intParam("param_a")],
+    });
+    await cleanWorkflow(wf, { toolInputsResolver: resolver });
+    expect((step.tool_state as Record<string, unknown>).param_a).toBe(42);
+    expect((step.tool_state as Record<string, unknown>).stale_key).toBeUndefined();
+  });
+
+  it("keeps all tool_state keys without resolver", async () => {
+    const step = nativeStep({ tool_state: { param_a: 42, stale_key: "old" } });
+    const wf = nativeWorkflow({ steps: { "0": step } });
+    await cleanWorkflow(wf);
+    expect((step.tool_state as Record<string, unknown>).stale_key).toBe("old");
+  });
+
+  it("gracefully skips tool-aware strip when tool not found in resolver", async () => {
+    const step = nativeStep({ tool_state: { param_a: 42, stale_key: "old" } });
+    const wf = nativeWorkflow({ steps: { "0": step } });
+    const resolver = mapResolver({}); // empty — tool not found
+    await cleanWorkflow(wf, { toolInputsResolver: resolver });
+    // Stale key preserved when tool not found
+    expect((step.tool_state as Record<string, unknown>).stale_key).toBe("old");
+  });
+});
+
+// ─── Tool-aware format2 cleaning ──────────────────────────────────────────────
+
+describe("cleanWorkflow — format2 tool-aware stale key removal", () => {
+  it("removes unexpected state key when resolver provided", async () => {
+    const step = format2Step({
+      state: { param_a: 42, stale_key: "old" },
+    });
+    const wf = format2Workflow({ steps: [step] });
+    const resolver = mapResolver({
+      "toolshed.g2.bx.psu.edu/repos/devteam/some_tool/some_tool/1.0": [intParam("param_a")],
+    });
+    await cleanWorkflow(wf, { toolInputsResolver: resolver });
+    expect((step.state as Record<string, unknown>).param_a).toBe(42);
+    expect((step.state as Record<string, unknown>).stale_key).toBeUndefined();
+  });
+
+  it("keeps unexpected state key without resolver", async () => {
+    const step = format2Step({
+      state: { param_a: 42, stale_key: "old" },
+    });
+    const wf = format2Workflow({ steps: [step] });
+    await cleanWorkflow(wf);
+    expect((step.state as Record<string, unknown>).stale_key).toBe("old");
+  });
+
+  it("gracefully skips format2 tool-aware strip when tool not found", async () => {
+    const step = format2Step({ state: { param_a: 42, stale_key: "old" } });
+    const wf = format2Workflow({ steps: [step] });
+    const resolver = mapResolver({});
+    await cleanWorkflow(wf, { toolInputsResolver: resolver });
+    expect((step.state as Record<string, unknown>).stale_key).toBe("old");
+  });
+});
+
+// ─── skipUuid option ──────────────────────────────────────────────────────────
+
+describe("cleanWorkflow — skipUuid option", () => {
+  it("preserves uuid on native workflow when skipUuid=true", async () => {
+    const wf = nativeWorkflow({ steps: {} });
+    await cleanWorkflow(wf, { skipUuid: true });
+    expect(wf.uuid).toBe("wf-uuid-1234");
+  });
+
+  it("preserves uuid on format2 workflow when skipUuid=true", async () => {
+    const wf = format2Workflow({ steps: [] });
+    await cleanWorkflow(wf, { skipUuid: true });
+    expect(wf.uuid).toBe("wf-uuid-format2");
+  });
+
+  it("preserves uuid on format2 step when skipUuid=true", async () => {
+    const step = format2Step();
+    const wf = format2Workflow({ steps: [step] });
+    await cleanWorkflow(wf, { skipUuid: true });
+    expect(step.uuid).toBe("step-uuid-format2");
+  });
+
+  it("still strips errors on format2 step when skipUuid=true", async () => {
+    const step = format2Step();
+    const wf = format2Workflow({ steps: [step] });
+    await cleanWorkflow(wf, { skipUuid: true });
+    expect(step.errors).toBeUndefined();
+  });
+});

--- a/packages/schema/test/declarative-wfstate.test.ts
+++ b/packages/schema/test/declarative-wfstate.test.ts
@@ -13,7 +13,8 @@ import * as path from "node:path";
 import * as S from "effect/Schema";
 import * as ParseResult from "effect/ParseResult";
 
-import { ToolCache, cacheKey, getCacheDir, type ParsedTool } from "@galaxy-tool-util/core";
+import { join } from "node:path";
+import { ToolCache, cacheKey, getCacheDir } from "@galaxy-tool-util/core";
 
 import {
   cleanWorkflow,
@@ -27,6 +28,8 @@ import {
   type NormalizedFormat2Workflow,
   type NormalizedFormat2Step,
   type ToolParameterBundleModel,
+  type ToolInputsResolver,
+  type ToolParameterModel,
 } from "../src/index.js";
 
 import { loadExpectations, runAssertions } from "./declarative-test-utils.js";
@@ -411,21 +414,50 @@ async function validateOp(wfDict: unknown): Promise<unknown> {
   return workflow;
 }
 
-function cleanOp(wfDict: unknown): unknown {
+function makeToolInputsResolver(): ToolInputsResolver | undefined {
+  if (!toolCacheAvailable()) return undefined;
+  const cache = new ToolCache();
+  return (toolId: string, toolVersion: string | null) => {
+    const coords = cache.resolveToolCoordinates(toolId, toolVersion);
+    const version = coords.version ?? "_default_";
+    const key = cacheKey(coords.toolshedUrl, coords.trsToolId, version);
+    const filePath = join(cache.cacheDir, `${key}.json`);
+    if (!fs.existsSync(filePath)) return undefined;
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      return (data.inputs ?? []) as ToolParameterModel[];
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+async function cleanOp(wfDict: unknown): Promise<unknown> {
   const workflow = structuredClone(wfDict as Record<string, unknown>);
-  return cleanWorkflow(workflow).workflow;
+  return (await cleanWorkflow(workflow, { toolInputsResolver: makeToolInputsResolver() })).workflow;
+}
+
+async function cleanSkipUuidOp(wfDict: unknown): Promise<unknown> {
+  const workflow = structuredClone(wfDict as Record<string, unknown>);
+  return (
+    await cleanWorkflow(workflow, { skipUuid: true, toolInputsResolver: makeToolInputsResolver() })
+  ).workflow;
 }
 
 async function validateCleanOp(wfDict: unknown): Promise<unknown> {
   // Clean an internal copy, then validate it — return original on success
-  const { workflow: cleaned } = cleanWorkflow(structuredClone(wfDict as Record<string, unknown>));
+  const { workflow: cleaned } = await cleanWorkflow(
+    structuredClone(wfDict as Record<string, unknown>),
+  );
   await validateOp(cleaned);
   return wfDict;
 }
 
 async function cleanThenValidateOp(wfDict: unknown): Promise<unknown> {
   // Mutating clean, then validate — return the cleaned workflow
-  const { workflow: cleaned } = cleanWorkflow(structuredClone(wfDict as Record<string, unknown>));
+  const { workflow: cleaned } = await cleanWorkflow(
+    structuredClone(wfDict as Record<string, unknown>),
+  );
   await validateOp(cleaned);
   return cleaned;
 }
@@ -433,6 +465,7 @@ async function cleanThenValidateOp(wfDict: unknown): Promise<unknown> {
 const OPERATIONS: Record<string, Operation> = {
   validate: validateOp,
   clean: cleanOp,
+  clean_skip_uuid: cleanSkipUuidOp,
   validate_clean: validateCleanOp,
   clean_then_validate: cleanThenValidateOp,
 };

--- a/packages/schema/test/declarative-wfstate.test.ts
+++ b/packages/schema/test/declarative-wfstate.test.ts
@@ -42,6 +42,8 @@ const WF_FIXTURES_DIR = path.join(FIXTURES_DIR, "fixtures");
 
 // Operations that require a populated tool cache to produce meaningful results
 const CACHE_DEPENDENT_OPERATIONS = new Set(["validate", "validate_clean", "clean_then_validate"]);
+// Tests that may fail without the tool cache (tool-aware state stripping needs resolver)
+const MAY_FAIL_WITHOUT_CACHE = new Set(["clean_format2_stale_keys_stripped"]);
 
 function toolCacheAvailable(): boolean {
   const dir = getCacheDir();
@@ -524,6 +526,14 @@ describe("declarative workflow_state tests", () => {
 
     if (CACHE_DEPENDENT_OPERATIONS.has(operation) && !toolCacheAvailable()) {
       it.skip(`${testId} (tool cache not populated)`, () => {});
+      continue;
+    }
+
+    if (MAY_FAIL_WITHOUT_CACHE.has(testId) && !toolCacheAvailable()) {
+      it.fails(testId, async () => {
+        const wf = await Promise.resolve(OPERATIONS[operation](loadWorkflow(fixture)));
+        runAssertions(wf, assertions);
+      });
       continue;
     }
 

--- a/packages/schema/test/fixtures/workflow-state/expectations/clean.yml
+++ b/packages/schema/test/fixtures/workflow-state/expectations/clean.yml
@@ -97,6 +97,17 @@ clean_format2_noop:
     - path: [steps, concat, state, queries]
       value_type: list
 
+clean_format2_stale_keys_stripped:
+  fixture: synthetic-cat1-stale.gxwf.yml
+  operation: clean
+  assertions:
+    - path: [steps, concat, state, chromInfo]
+      value_absent: true
+    - path: [steps, concat, state, stale_param]
+      value_absent: true
+    - path: [steps, concat, state, queries]
+      value_type: list
+
 # --- IWC workflows ---
 
 clean_iwc_repeatmasking_bookkeeping_stripped:
@@ -138,6 +149,54 @@ clean_iwc_rnaseq_subworkflow_bookkeeping_stripped:
       value_absent: true
     - path: [steps, "17", subworkflow, steps, "2", tool_state, __rerun_remap_job_id__]
       value_absent: true
+
+# --- Structural step cleaning ---
+
+clean_strips_step_uuid:
+  fixture: rnaseq-sr.ga
+  operation: clean
+  assertions:
+    - path: [steps, "10", uuid]
+      value_absent: true
+
+clean_preserves_step_position:
+  fixture: rnaseq-sr.ga
+  operation: clean
+  assertions:
+    - path: [steps, "10", position]
+      value_type: dict
+
+clean_skip_uuid_preserves_uuid:
+  fixture: rnaseq-sr.ga
+  operation: clean_skip_uuid
+  assertions:
+    - path: [steps, "10", uuid]
+      value_type: str
+
+clean_strips_step_errors:
+  fixture: synthetic-cat1-errors.ga
+  operation: clean
+  assertions:
+    - path: [steps, "1", errors]
+      value_absent: true
+
+clean_strips_step_uuid_from_errors_fixture:
+  fixture: synthetic-cat1-errors.ga
+  operation: clean
+  assertions:
+    - path: [steps, "1", uuid]
+      value_absent: true
+
+clean_skip_uuid_preserves_uuid_from_errors_fixture:
+  fixture: synthetic-cat1-errors.ga
+  operation: clean_skip_uuid
+  assertions:
+    - path: [steps, "1", uuid]
+      value_type: str
+    - path: [steps, "1", errors]
+      value_absent: true
+
+# ---
 
 clean_iwc_rnaseq_subworkflow_valid_inputs_survive:
   fixture: rnaseq-sr.ga

--- a/packages/schema/test/fixtures/workflow-state/expectations/strict.yml
+++ b/packages/schema/test/fixtures/workflow-state/expectations/strict.yml
@@ -1,0 +1,67 @@
+# Declarative tests for --strict-structure, --strict-encoding, --strict-state.
+
+# --- strict-structure ---
+
+strict_structure_extra_keys:
+  fixture: synthetic-cat1-extra-keys.ga
+  operation: strict_structure
+  expect_error: true
+
+strict_structure_clean:
+  fixture: synthetic-cat1-clean.ga
+  operation: strict_structure
+  assertions:
+    - path: [steps, "1", tool_id]
+      value: cat1
+
+strict_structure_format2_clean:
+  fixture: synthetic-cat1.gxwf.yml
+  operation: strict_structure
+  assertions:
+    - path: [steps, concat, tool_id]
+      value: cat1
+
+# --- strict-encoding ---
+
+strict_encoding_json_string_tool_state:
+  fixture: synthetic-cat1-json-string-state.ga
+  operation: strict_encoding
+  expect_error: true
+
+strict_encoding_tool_state_in_format2:
+  fixture: synthetic-cat1-format2-tool-state.gxwf.yml
+  operation: strict_encoding
+  expect_error: true
+
+strict_encoding_clean_native:
+  fixture: synthetic-cat1-clean.ga
+  operation: strict_encoding
+  assertions:
+    - path: [steps, "1", tool_state]
+      value_type: dict
+
+strict_encoding_clean_format2:
+  fixture: synthetic-cat1.gxwf.yml
+  operation: strict_encoding
+  assertions:
+    - path: [steps, concat, tool_id]
+      value: cat1
+
+# --- strict-state ---
+
+strict_state_missing_tool:
+  fixture: synthetic-missing-tool.ga
+  operation: strict_state_validate
+  expect_error: true
+
+strict_state_legacy_encoding:
+  fixture: test_workflow_1.ga
+  operation: strict_state_validate
+  expect_error: true
+
+strict_state_clean_passes:
+  fixture: synthetic-cat1-clean.ga
+  operation: strict_state_validate
+  assertions:
+    - path: [steps, "1", tool_id]
+      value: cat1

--- a/packages/schema/test/fixtures/workflow-state/fixtures/synthetic-cat1-errors.ga
+++ b/packages/schema/test/fixtures/workflow-state/fixtures/synthetic-cat1-errors.ga
@@ -1,0 +1,34 @@
+{
+    "a_galaxy_workflow": "true",
+    "format-version": "0.1",
+    "name": "Synthetic Cat1 With Step Errors and UUID",
+    "steps": {
+        "0": {
+            "type": "data_input",
+            "tool_id": null,
+            "label": "input_dataset",
+            "tool_state": {
+                "name": "input_dataset"
+            }
+        },
+        "1": {
+            "type": "tool",
+            "tool_id": "cat1",
+            "tool_version": "1.0.0",
+            "label": "concat",
+            "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "errors": "Tool not found",
+            "tool_state": {
+                "input1": {"__class__": "RuntimeValue"},
+                "queries": [],
+                "chromInfo": "?"
+            },
+            "input_connections": {
+                "input1": {"id": 0, "output_name": "output"}
+            },
+            "workflow_outputs": [
+                {"label": "concatenated", "output_name": "out_file1"}
+            ]
+        }
+    }
+}

--- a/packages/schema/test/fixtures/workflow-state/fixtures/synthetic-cat1-stale.gxwf.yml
+++ b/packages/schema/test/fixtures/workflow-state/fixtures/synthetic-cat1-stale.gxwf.yml
@@ -1,0 +1,19 @@
+class: GalaxyWorkflow
+label: Synthetic Cat1 Format2 With Stale Keys
+inputs:
+  input_dataset:
+    type: data
+steps:
+  concat:
+    tool_id: cat1
+    tool_version: "1.0.0"
+    in:
+      input1:
+        source: input_dataset
+    state:
+      queries: []
+      chromInfo: "hg19"
+      stale_param: "unused"
+outputs:
+  concatenated:
+    outputSource: concat/out_file1

--- a/packages/schema/test/walker.test.ts
+++ b/packages/schema/test/walker.test.ts
@@ -530,14 +530,15 @@ describe("walkFormat2State", () => {
       const repeat = repeatParam("queries", [textParam("input")]);
       const state = { queries: [] };
       const result = walkFormat2State([repeat], state, identity);
-      // Empty array → no instances → omitted from output
-      expect(result).toEqual({});
+      // Explicit empty array preserved (valid state)
+      expect(result).toEqual({ queries: [] });
     });
 
     it("handles missing repeat state", () => {
       const repeat = repeatParam("queries", [textParam("input")]);
       const state = {};
       const result = walkFormat2State([repeat], state, identity);
+      // Absent key stays absent
       expect(result).toEqual({});
     });
   });


### PR DESCRIPTION
- Strip uuid/errors from workflow and step dicts (both native + format2)
- Format2 workflows now return per-step CleanStepResult[]
- New toolInputsResolver option wires stripStaleKeysToolAware (native) and walkFormat2State (format2) into the clean path
- New skipUuid option (and --skip-uuid CLI flag) preserves uuid fields; errors are always stripped regardless
- cleanWorkflow() is now async (returns Promise<CleanWorkflowResult>)
- Export CleanWorkflowOptions from @galaxy-tool-util/schema