### PR TITLE
Add strict options, clean-first, mode selector, and before/after cont…

### DIFF
--- a/.changeset/gxwf-web-v2-strict-mode-clean-first.md
+++ b/.changeset/gxwf-web-v2-strict-mode-clean-first.md
@@ -1,0 +1,30 @@
+---
+"@galaxy-tool-util/schema": minor
+"@galaxy-tool-util/cli": minor
+"@galaxy-tool-util/gxwf-web": minor
+"@galaxy-tool-util/gxwf-report-shell": minor
+---
+
+Expose fine-grained strict options, clean-first validation, JSON-schema mode, and before/after workflow content in the gxwf-web server and report UI.
+
+**`@galaxy-tool-util/schema`**
+- `SingleCleanReport` += `before_content?: string | null`, `after_content?: string | null`
+- `SingleRoundTripReport` += `before_content?: string | null`, `after_content?: string | null`
+- `SingleValidationReport` += `clean_report?: SingleCleanReport | null`
+- `RoundtripResult` += `reimportedWorkflow?: unknown` (populated by `roundtripValidate` on success)
+
+**`@galaxy-tool-util/cli`**
+- New export: `decodeStructureErrorsJsonSchema(data, format)` — AJV-based structural error decoder matching the `decodeStructureErrors` signature
+- New exports: `validateNativeStepsJsonSchema`, `validateFormat2StepsJsonSchema` re-exported from CLI index
+
+**`@galaxy-tool-util/gxwf-web`**
+- `ValidateOptions`: replaced `strict` with `strict_structure` + `strict_encoding`; added `clean_first` (runs clean in-memory before validation, embeds `clean_report`) and `mode` (routes to AJV path when `"json-schema"`)
+- `LintOptions`: replaced `strict` with `strict_structure` + `strict_encoding`
+- `CleanOptions` += `include_content` — populates `before_content`/`after_content` on the returned report
+- New `RoundtripOptions` interface with `strict_structure`, `strict_encoding`, `strict_state`, `include_content`
+- `openapi.json` regenerated from Python FastAPI server; `api-types.ts` regenerated via `pnpm codegen`
+
+**`@galaxy-tool-util/gxwf-report-shell`**
+- `CleanReport.vue`: shows collapsed "Workflow content" panel with before/after `<pre>` panes when content fields are present
+- `RoundtripReport.vue`: shows collapsed "Workflow content" panel with "Original" / "Re-imported" tabs when content fields are present
+- `ValidationReport.vue`: shows collapsed "Pre-validation clean" panel (renders `CleanReport`) when `clean_report` is present

--- a/packages/cli/src/commands/validate-workflow-json-schema.ts
+++ b/packages/cli/src/commands/validate-workflow-json-schema.ts
@@ -157,6 +157,27 @@ function formatAjvErrors(validate: ValidateFunction): string[] {
   });
 }
 
+/**
+ * Validate workflow structure using the AJV-compiled JSON Schema (Draft 2020-12).
+ * Returns an array of error strings; empty if valid.
+ * Mirrors `decodeStructureErrors` but uses the AJV path instead of Effect decode.
+ */
+export function decodeStructureErrorsJsonSchema(
+  data: Record<string, unknown>,
+  format: WorkflowFormat,
+): string[] {
+  const validationData = { ...data };
+  if (format === "native" && !("class" in validationData)) {
+    validationData.class = "NativeGalaxyWorkflow";
+  } else if (format === "format2" && !("class" in validationData)) {
+    validationData.class = "GalaxyWorkflow";
+  }
+  const structValidator =
+    format === "native" ? nativeStructuralValidator() : format2StructuralValidator();
+  const ok = structValidator(validationData);
+  return ok ? [] : formatAjvErrors(structValidator);
+}
+
 // --- main entry point ---
 
 export async function runValidateWorkflowJsonSchema(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -61,3 +61,9 @@ export { loadToolInputsForWorkflow } from "./commands/stateful-tool-inputs.js";
 export type { ToolLoadStatus, LoadedToolInputs } from "./commands/stateful-tool-inputs.js";
 /** Default subworkflow ref resolver (base64, TRS, HTTP, file paths). */
 export { createDefaultResolver } from "./commands/url-resolver.js";
+/** JSON-Schema-based (AJV) step validation and structural error decoding. */
+export {
+  validateNativeStepsJsonSchema,
+  validateFormat2StepsJsonSchema,
+  decodeStructureErrorsJsonSchema,
+} from "./commands/validate-workflow-json-schema.js";

--- a/packages/gxwf-report-shell/src/CleanReport.vue
+++ b/packages/gxwf-report-shell/src/CleanReport.vue
@@ -30,11 +30,30 @@
         </template>
       </Column>
     </DataTable>
+
+    <Panel
+      v-if="report.before_content != null || report.after_content != null"
+      header="Workflow content"
+      :toggleable="true"
+      :collapsed="true"
+    >
+      <div class="content-panes">
+        <div class="content-pane">
+          <div class="pane-label">Before</div>
+          <pre class="content-pre">{{ report.before_content ?? "(none)" }}</pre>
+        </div>
+        <div class="content-pane">
+          <div class="pane-label">After</div>
+          <pre class="content-pre">{{ report.after_content ?? "(none)" }}</pre>
+        </div>
+      </div>
+    </Panel>
   </div>
 </template>
 
 <script setup lang="ts">
 import DataTable from "primevue/datatable";
+import Panel from "primevue/panel";
 import type { SingleCleanReport, CleanStepResult } from "@galaxy-tool-util/schema";
 import Column from "primevue/column";
 import Tag from "primevue/tag";
@@ -67,5 +86,38 @@ defineProps<{
 .no-changes {
   color: var(--p-text-color-secondary, #6c757d);
   font-style: italic;
+}
+
+.content-panes {
+  display: flex;
+  gap: 1rem;
+}
+
+.content-pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.pane-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--p-text-color-secondary, #6c757d);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.content-pre {
+  margin: 0;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  background: var(--p-surface-100, #f8f9fa);
+  border: 1px solid var(--p-surface-300, #dee2e6);
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 400px;
+  white-space: pre;
 }
 </style>

--- a/packages/gxwf-report-shell/src/RoundtripReport.vue
+++ b/packages/gxwf-report-shell/src/RoundtripReport.vue
@@ -37,6 +37,28 @@
         <Column field="description" header="Description" />
       </DataTable>
     </template>
+
+    <Panel
+      v-if="report.before_content != null || report.after_content != null"
+      header="Workflow content"
+      :toggleable="true"
+      :collapsed="true"
+    >
+      <Tabs value="original">
+        <TabList>
+          <Tab value="original">Original (native)</Tab>
+          <Tab value="reimported">Re-imported (native)</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel value="original">
+            <pre class="content-pre">{{ report.before_content ?? "(none)" }}</pre>
+          </TabPanel>
+          <TabPanel value="reimported">
+            <pre class="content-pre">{{ report.after_content ?? "(none)" }}</pre>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Panel>
   </div>
 </template>
 
@@ -45,6 +67,12 @@ import { computed } from "vue";
 import type { SingleRoundTripReport } from "@galaxy-tool-util/schema";
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
+import Panel from "primevue/panel";
+import Tab from "primevue/tab";
+import TabList from "primevue/tablist";
+import TabPanel from "primevue/tabpanel";
+import TabPanels from "primevue/tabpanels";
+import Tabs from "primevue/tabs";
 import Tag from "primevue/tag";
 import Message from "primevue/message";
 
@@ -85,5 +113,17 @@ const result = computed(() => props.report.result);
   margin: 0;
   padding-left: 1.25rem;
   font-size: 0.85rem;
+}
+
+.content-pre {
+  margin: 0;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  background: var(--p-surface-100, #f8f9fa);
+  border: 1px solid var(--p-surface-300, #dee2e6);
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 500px;
+  white-space: pre;
 }
 </style>

--- a/packages/gxwf-report-shell/src/ValidationReport.vue
+++ b/packages/gxwf-report-shell/src/ValidationReport.vue
@@ -13,6 +13,15 @@
       </Message>
     </template>
 
+    <Panel
+      v-if="report.clean_report != null"
+      header="Pre-validation clean"
+      :toggleable="true"
+      :collapsed="true"
+    >
+      <CleanReport :report="report.clean_report" />
+    </Panel>
+
     <div class="summary-row">
       <Tag
         v-for="(count, key) in report.summary"
@@ -50,8 +59,10 @@ import { computed } from "vue";
 import type { SingleValidationReport, ValidationStepResult } from "@galaxy-tool-util/schema";
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
+import Panel from "primevue/panel";
 import Tag from "primevue/tag";
 import Message from "primevue/message";
+import CleanReport from "./CleanReport.vue";
 import ToolId from "./ToolId.vue";
 
 const props = defineProps<{

--- a/packages/gxwf-ui/src/components/OperationPanel.vue
+++ b/packages/gxwf-ui/src/components/OperationPanel.vue
@@ -16,8 +16,28 @@
                 icon="pi pi-play"
                 size="small"
                 :loading="validateLoading"
-                @click="() => void runValidate()"
+                @click="() => void runValidate(validateOpts)"
               />
+              <Select
+                v-model="validateOpts.mode"
+                :options="modeOptions"
+                option-label="label"
+                option-value="value"
+                size="small"
+                class="mode-select"
+              />
+              <label class="opt-label">
+                <Checkbox v-model="validateOpts.strict_structure" :binary="true" size="small" />
+                Strict structure
+              </label>
+              <label class="opt-label">
+                <Checkbox v-model="validateOpts.strict_encoding" :binary="true" size="small" />
+                Strict encoding
+              </label>
+              <label class="opt-label">
+                <Checkbox v-model="validateOpts.clean_first" :binary="true" size="small" />
+                Clean first
+              </label>
               <ToggleButton
                 v-if="validateResult"
                 v-model="showRaw.validate"
@@ -45,8 +65,16 @@
                 icon="pi pi-play"
                 size="small"
                 :loading="lintLoading"
-                @click="() => void runLint()"
+                @click="() => void runLint(lintOpts)"
               />
+              <label class="opt-label">
+                <Checkbox v-model="lintOpts.strict_structure" :binary="true" size="small" />
+                Strict structure
+              </label>
+              <label class="opt-label">
+                <Checkbox v-model="lintOpts.strict_encoding" :binary="true" size="small" />
+                Strict encoding
+              </label>
               <ToggleButton
                 v-if="lintResult"
                 v-model="showRaw.lint"
@@ -74,8 +102,12 @@
                 icon="pi pi-play"
                 size="small"
                 :loading="cleanLoading"
-                @click="() => void runClean()"
+                @click="() => void runClean(cleanOpts)"
               />
+              <label class="opt-label">
+                <Checkbox v-model="cleanOpts.include_content" :binary="true" size="small" />
+                Show workflow diff
+              </label>
               <ToggleButton
                 v-if="cleanResult"
                 v-model="showRaw.clean"
@@ -103,8 +135,24 @@
                 icon="pi pi-play"
                 size="small"
                 :loading="roundtripLoading"
-                @click="() => void runRoundtrip()"
+                @click="() => void runRoundtrip(roundtripOpts)"
               />
+              <label class="opt-label">
+                <Checkbox v-model="roundtripOpts.strict_structure" :binary="true" size="small" />
+                Strict structure
+              </label>
+              <label class="opt-label">
+                <Checkbox v-model="roundtripOpts.strict_encoding" :binary="true" size="small" />
+                Strict encoding
+              </label>
+              <label class="opt-label">
+                <Checkbox v-model="roundtripOpts.strict_state" :binary="true" size="small" />
+                Strict state
+              </label>
+              <label class="opt-label">
+                <Checkbox v-model="roundtripOpts.include_content" :binary="true" size="small" />
+                Show workflow content
+              </label>
               <ToggleButton
                 v-if="roundtripResult"
                 v-model="showRaw.roundtrip"
@@ -136,6 +184,8 @@ import Tab from "primevue/tab";
 import TabPanels from "primevue/tabpanels";
 import TabPanel from "primevue/tabpanel";
 import Button from "primevue/button";
+import Checkbox from "primevue/checkbox";
+import Select from "primevue/select";
 import ToggleButton from "primevue/togglebutton";
 import Message from "primevue/message";
 import {
@@ -145,7 +195,13 @@ import {
   RoundtripReport,
   RawJsonView,
 } from "@galaxy-tool-util/gxwf-report-shell";
-import { useOperation } from "../composables/useOperation";
+import {
+  useOperation,
+  type ValidateOpts,
+  type LintOpts,
+  type CleanOpts,
+  type RoundtripOpts,
+} from "../composables/useOperation";
 
 const props = defineProps<{
   workflowPath: string;
@@ -173,6 +229,34 @@ const {
   runRoundtrip,
 } = useOperation(props.workflowPath);
 
+const modeOptions = [
+  { label: "Meta model", value: "effect" },
+  { label: "JSON Schema", value: "json-schema" },
+];
+
+const validateOpts = reactive<ValidateOpts>({
+  strict_structure: false,
+  strict_encoding: false,
+  mode: "effect",
+  clean_first: false,
+});
+
+const lintOpts = reactive<LintOpts>({
+  strict_structure: false,
+  strict_encoding: false,
+});
+
+const cleanOpts = reactive<CleanOpts>({
+  include_content: false,
+});
+
+const roundtripOpts = reactive<RoundtripOpts>({
+  strict_structure: false,
+  strict_encoding: false,
+  strict_state: false,
+  include_content: false,
+});
+
 const showRaw = reactive({ validate: false, lint: false, clean: false, roundtrip: false });
 </script>
 
@@ -194,6 +278,20 @@ const showRaw = reactive({ validate: false, lint: false, clean: false, roundtrip
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.mode-select {
+  width: 9rem;
+}
+
+.opt-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  white-space: nowrap;
 }
 
 .no-results {

--- a/packages/gxwf-ui/src/composables/useOperation.ts
+++ b/packages/gxwf-ui/src/composables/useOperation.ts
@@ -71,6 +71,29 @@ export function clearOpCache(workflowPath: string) {
   delete opCache[workflowPath];
 }
 
+export interface ValidateOpts {
+  strict_structure?: boolean;
+  strict_encoding?: boolean;
+  mode?: string;
+  clean_first?: boolean;
+}
+
+export interface LintOpts {
+  strict_structure?: boolean;
+  strict_encoding?: boolean;
+}
+
+export interface CleanOpts {
+  include_content?: boolean;
+}
+
+export interface RoundtripOpts {
+  strict_structure?: boolean;
+  strict_encoding?: boolean;
+  strict_state?: boolean;
+  include_content?: boolean;
+}
+
 export function useOperation(workflowPath: string) {
   const client = useApi();
 
@@ -89,13 +112,21 @@ export function useOperation(workflowPath: string) {
   const cleanError = computed(() => ensureState(workflowPath).error.clean ?? null);
   const roundtripError = computed(() => ensureState(workflowPath).error.roundtrip ?? null);
 
-  async function runValidate() {
+  async function runValidate(opts: ValidateOpts = {}) {
     const s = ensureState(workflowPath);
     s.loading.validate = true;
     s.error.validate = null;
     try {
       const { data, error } = await client.GET("/workflows/{workflow_path}/validate", {
-        params: { path: { workflow_path: workflowPath } },
+        params: {
+          path: { workflow_path: workflowPath },
+          query: {
+            strict_structure: opts.strict_structure ?? false,
+            strict_encoding: opts.strict_encoding ?? false,
+            mode: opts.mode ?? undefined,
+            clean_first: opts.clean_first ?? false,
+          },
+        },
       });
       if (error) {
         s.error.validate = "Failed to validate workflow";
@@ -107,13 +138,19 @@ export function useOperation(workflowPath: string) {
     }
   }
 
-  async function runLint() {
+  async function runLint(opts: LintOpts = {}) {
     const s = ensureState(workflowPath);
     s.loading.lint = true;
     s.error.lint = null;
     try {
       const { data, error } = await client.GET("/workflows/{workflow_path}/lint", {
-        params: { path: { workflow_path: workflowPath } },
+        params: {
+          path: { workflow_path: workflowPath },
+          query: {
+            strict_structure: opts.strict_structure ?? false,
+            strict_encoding: opts.strict_encoding ?? false,
+          },
+        },
       });
       if (error) {
         s.error.lint = "Failed to lint workflow";
@@ -125,13 +162,18 @@ export function useOperation(workflowPath: string) {
     }
   }
 
-  async function runClean() {
+  async function runClean(opts: CleanOpts = {}) {
     const s = ensureState(workflowPath);
     s.loading.clean = true;
     s.error.clean = null;
     try {
       const { data, error } = await client.GET("/workflows/{workflow_path}/clean", {
-        params: { path: { workflow_path: workflowPath } },
+        params: {
+          path: { workflow_path: workflowPath },
+          query: {
+            include_content: opts.include_content ?? false,
+          },
+        },
       });
       if (error) {
         s.error.clean = "Failed to clean workflow";
@@ -143,13 +185,21 @@ export function useOperation(workflowPath: string) {
     }
   }
 
-  async function runRoundtrip() {
+  async function runRoundtrip(opts: RoundtripOpts = {}) {
     const s = ensureState(workflowPath);
     s.loading.roundtrip = true;
     s.error.roundtrip = null;
     try {
       const { data, error } = await client.GET("/workflows/{workflow_path}/roundtrip", {
-        params: { path: { workflow_path: workflowPath } },
+        params: {
+          path: { workflow_path: workflowPath },
+          query: {
+            strict_structure: opts.strict_structure ?? false,
+            strict_encoding: opts.strict_encoding ?? false,
+            strict_state: opts.strict_state ?? false,
+            include_content: opts.include_content ?? false,
+          },
+        },
       });
       if (error) {
         s.error.roundtrip = "Failed to run roundtrip";

--- a/packages/gxwf-web/openapi.json
+++ b/packages/gxwf-web/openapi.json
@@ -60,13 +60,23 @@
             }
           },
           {
-            "name": "strict",
+            "name": "strict_structure",
             "in": "query",
             "required": false,
             "schema": {
               "type": "boolean",
               "default": false,
-              "title": "Strict"
+              "title": "Strict Structure"
+            }
+          },
+          {
+            "name": "strict_encoding",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Strict Encoding"
             }
           },
           {
@@ -87,6 +97,16 @@
               "type": "string",
               "default": "pydantic",
               "title": "Mode"
+            }
+          },
+          {
+            "name": "clean_first",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Clean First"
             }
           },
           {
@@ -179,6 +199,16 @@
               },
               "default": [],
               "title": "Strip"
+            }
+          },
+          {
+            "name": "include_content",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Content"
             }
           }
         ],
@@ -299,6 +329,46 @@
             "schema": {
               "type": "string",
               "title": "Workflow Path"
+            }
+          },
+          {
+            "name": "strict_structure",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Strict Structure"
+            }
+          },
+          {
+            "name": "strict_encoding",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Strict Encoding"
+            }
+          },
+          {
+            "name": "strict_state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Strict State"
+            }
+          },
+          {
+            "name": "include_content",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Content"
             }
           }
         ],
@@ -857,13 +927,23 @@
             }
           },
           {
-            "name": "strict",
+            "name": "strict_structure",
             "in": "query",
             "required": false,
             "schema": {
               "type": "boolean",
               "default": false,
-              "title": "Strict"
+              "title": "Strict Structure"
+            }
+          },
+          {
+            "name": "strict_encoding",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Strict Encoding"
             }
           },
           {
@@ -988,12 +1068,20 @@
             ],
             "title": "Version"
           },
-          "removed_keys": {
+          "removed_state_keys": {
             "items": {
               "type": "string"
             },
             "type": "array",
-            "title": "Removed Keys",
+            "title": "Removed State Keys",
+            "default": []
+          },
+          "removed_step_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Removed Step Keys",
             "default": []
           },
           "skipped": {
@@ -1692,6 +1780,28 @@
             "type": "array",
             "title": "Results"
           },
+          "before_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Before Content"
+          },
+          "after_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "After Content"
+          },
           "total_removed": {
             "type": "integer",
             "title": "Total Removed",
@@ -1814,6 +1924,28 @@
           },
           "result": {
             "$ref": "#/components/schemas/RoundTripValidationResult"
+          },
+          "before_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Before Content"
+          },
+          "after_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "After Content"
           }
         },
         "type": "object",
@@ -1871,6 +2003,16 @@
             },
             "type": "array",
             "title": "Encoding Errors"
+          },
+          "clean_report": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SingleCleanReport"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "summary": {
             "additionalProperties": {
@@ -2079,7 +2221,7 @@
           },
           "diffs": {
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/StepDiff"
             },
             "type": "array",
             "title": "Diffs"

--- a/packages/gxwf-web/src/generated/api-types.ts
+++ b/packages/gxwf-web/src/generated/api-types.ts
@@ -309,10 +309,15 @@ export interface components {
       /** Version */
       version?: string | null;
       /**
-       * Removed Keys
+       * Removed State Keys
        * @default []
        */
-      removed_keys: string[];
+      removed_state_keys: string[];
+      /**
+       * Removed Step Keys
+       * @default []
+       */
+      removed_step_keys: string[];
       /**
        * Skipped
        * @default false
@@ -621,6 +626,10 @@ export interface components {
       workflow: string;
       /** Results */
       results: components["schemas"]["CleanStepResult"][];
+      /** Before Content */
+      before_content?: string | null;
+      /** After Content */
+      after_content?: string | null;
       /** Total Removed */
       readonly total_removed: number;
       /** Steps With Removals */
@@ -692,6 +701,10 @@ export interface components {
       /** Workflow */
       workflow: string;
       result: components["schemas"]["RoundTripValidationResult"];
+      /** Before Content */
+      before_content?: string | null;
+      /** After Content */
+      after_content?: string | null;
     };
     /**
      * SingleValidationReport
@@ -709,6 +722,7 @@ export interface components {
       structure_errors?: string[];
       /** Encoding Errors */
       encoding_errors?: string[];
+      clean_report?: components["schemas"]["SingleCleanReport"] | null;
       /** Summary */
       readonly summary: {
         [key: string]: number;
@@ -777,7 +791,7 @@ export interface components {
       /** Error */
       error?: string | null;
       /** Diffs */
-      diffs?: string[];
+      diffs?: components["schemas"]["StepDiff"][];
       /** Format2 State */
       format2_state?: {
         [key: string]: unknown;
@@ -906,9 +920,11 @@ export interface operations {
   validate_workflow_workflows__workflow_path__validate_get: {
     parameters: {
       query?: {
-        strict?: boolean;
+        strict_structure?: boolean;
+        strict_encoding?: boolean;
         connections?: boolean;
         mode?: string;
+        clean_first?: boolean;
         allow?: string[];
         deny?: string[];
       };
@@ -945,6 +961,7 @@ export interface operations {
       query?: {
         preserve?: string[];
         strip?: string[];
+        include_content?: boolean;
       };
       header?: never;
       path: {
@@ -1038,7 +1055,12 @@ export interface operations {
   };
   roundtrip_workflow_workflows__workflow_path__roundtrip_get: {
     parameters: {
-      query?: never;
+      query?: {
+        strict_structure?: boolean;
+        strict_encoding?: boolean;
+        strict_state?: boolean;
+        include_content?: boolean;
+      };
       header?: never;
       path: {
         workflow_path: string;
@@ -1427,7 +1449,8 @@ export interface operations {
   lint_workflow_workflows__workflow_path__lint_get: {
     parameters: {
       query?: {
-        strict?: boolean;
+        strict_structure?: boolean;
+        strict_encoding?: boolean;
         allow?: string[];
         deny?: string[];
       };

--- a/packages/gxwf-web/src/router.ts
+++ b/packages/gxwf-web/src/router.ts
@@ -43,6 +43,7 @@ import {
   type ValidateOptions,
   type LintOptions,
   type CleanOptions,
+  type RoundtripOptions,
 } from "./workflows.js";
 
 // ── State ────────────────────────────────────────────────────────────
@@ -310,9 +311,11 @@ export function createRequestHandler(state: AppState) {
           switch (route.op) {
             case "validate": {
               const vopts: ValidateOptions = {
-                strict: route.query.get("strict") === "true",
+                strict_structure: route.query.get("strict_structure") === "true",
+                strict_encoding: route.query.get("strict_encoding") === "true",
                 connections: route.query.get("connections") === "true",
                 mode: route.query.get("mode") ?? undefined,
+                clean_first: route.query.get("clean_first") === "true",
                 allow: route.query.getAll("allow"),
                 deny: route.query.getAll("deny"),
               };
@@ -321,7 +324,8 @@ export function createRequestHandler(state: AppState) {
             }
             case "lint": {
               const lopts: LintOptions = {
-                strict: route.query.get("strict") === "true",
+                strict_structure: route.query.get("strict_structure") === "true",
+                strict_encoding: route.query.get("strict_encoding") === "true",
                 allow: route.query.getAll("allow"),
                 deny: route.query.getAll("deny"),
               };
@@ -332,6 +336,7 @@ export function createRequestHandler(state: AppState) {
               const copts: CleanOptions = {
                 preserve: route.query.getAll("preserve"),
                 strip: route.query.getAll("strip"),
+                include_content: route.query.get("include_content") === "true",
               };
               result = await operateClean(wf, copts);
               break;
@@ -342,9 +347,16 @@ export function createRequestHandler(state: AppState) {
             case "to-native":
               result = await operateToNative(wf, state.cache);
               break;
-            case "roundtrip":
-              result = await operateRoundtrip(wf, state.cache);
+            case "roundtrip": {
+              const ropts: RoundtripOptions = {
+                strict_structure: route.query.get("strict_structure") === "true",
+                strict_encoding: route.query.get("strict_encoding") === "true",
+                strict_state: route.query.get("strict_state") === "true",
+                include_content: route.query.get("include_content") === "true",
+              };
+              result = await operateRoundtrip(wf, state.cache, ropts);
               break;
+            }
           }
           json(res, 200, result);
           break;

--- a/packages/gxwf-web/src/workflows.ts
+++ b/packages/gxwf-web/src/workflows.ts
@@ -26,7 +26,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import type { ToolCache } from "@galaxy-tool-util/core";
 import {
   cleanWorkflow,
@@ -54,6 +54,7 @@ import {
   type ExpansionOptions,
   type ValidationStepResult,
   type RoundtripFailureClass,
+  type CleanStepResult,
 } from "@galaxy-tool-util/schema";
 import {
   validateNativeSteps,
@@ -63,6 +64,9 @@ import {
   loadToolInputsForWorkflow,
   createDefaultResolver,
   lintWorkflowReport,
+  validateNativeStepsJsonSchema,
+  validateFormat2StepsJsonSchema,
+  decodeStructureErrorsJsonSchema,
 } from "@galaxy-tool-util/cli";
 import { HttpError } from "./contents.js";
 
@@ -201,18 +205,26 @@ export function loadWorkflowFile(directory: string, relPath: string): WorkflowFi
 // ── Operations ───────────────────────────────────────────────────────────────
 
 export interface ValidateOptions {
-  /** Treat encoding/structure issues as errors (mirrors Python strict=True). */
-  strict?: boolean;
+  /** Reject unknown keys at envelope/step level (mirrors Python strict_structure). */
+  strict_structure?: boolean;
+  /** Reject JSON-string tool_state and format2 field misuse (mirrors Python strict_encoding). */
+  strict_encoding?: boolean;
   /**
    * Validate connections between steps. Not yet implemented in TS — accepted
    * for API parity but silently ignored.
    */
   connections?: boolean;
   /**
-   * Validation mode. Python default "pydantic" maps to TS default "effect".
-   * "json-schema" is accepted but currently treated as "effect".
+   * Validation mode: "effect" (default) uses Effect Schema decode;
+   * "json-schema" uses AJV against the generated JSON Schema (mirrors Python --mode json-schema).
+   * Python default "pydantic" is treated as "effect".
    */
   mode?: string;
+  /**
+   * Run clean in-memory before validating. Results are embedded in the
+   * returned report as clean_report.
+   */
+  clean_first?: boolean;
   /**
    * Tool IDs whose stale keys are allowed. Accepted for API parity; requires
    * StaleKeyPolicy (future work) — currently ignored.
@@ -231,20 +243,54 @@ export async function operateValidate(
   cache: ToolCache,
   opts: ValidateOptions = {},
 ): Promise<SingleValidationReport> {
-  const { absPath, data, format } = wf;
-  const structureErrors = opts.strict ? decodeStructureErrors(data, format) : [];
+  const { absPath, format } = wf;
+  let { data } = wf;
+  const useJsonSchema = opts.mode === "json-schema";
   const expansionOpts: ExpansionOptions = {
     resolver: createDefaultResolver({ workflowDirectory: path.dirname(absPath) }),
   };
 
-  let results: ValidationStepResult[] = [];
+  // Optional clean-first pass: run clean in-memory, validate on cleaned dict
+  let clean_report: SingleCleanReport | null = null;
+  if (opts.clean_first) {
+    const cleanResult = await cleanWorkflow(data);
+    const cleanResults = cleanResult.results as CleanStepResult[];
+    clean_report = buildSingleCleanReport(absPath, cleanResults);
+    data = cleanResult.workflow as Record<string, unknown>;
+  }
+
+  // Structural validation
+  const structureErrors = useJsonSchema
+    ? decodeStructureErrorsJsonSchema(data, format)
+    : opts.strict_structure
+      ? decodeStructureErrors(data, format)
+      : [];
+
+  // Encoding errors (only in strict_encoding mode via Effect path)
   const encodingErrors: string[] = [];
+  if (opts.strict_encoding && !useJsonSchema) {
+    // decodeStructureErrors covers encoding signals; encoding errors surfaced via detectEncodingErrors
+    if (cache.index.listAll().length > 0) {
+      const encErrors = await detectEncodingErrors(data, cache, format, expansionOpts);
+      encodingErrors.push(...encErrors);
+    }
+  }
+
+  let results: ValidationStepResult[] = [];
 
   try {
-    if (format === "native") {
-      results = await validateNativeSteps(data, cache, "", expansionOpts);
+    if (useJsonSchema) {
+      if (format === "native") {
+        results = await validateNativeStepsJsonSchema(data, cache, undefined, "", expansionOpts);
+      } else {
+        results = await validateFormat2StepsJsonSchema(data, cache, undefined, "", expansionOpts);
+      }
     } else {
-      results = await validateFormat2Steps(data, cache, "", expansionOpts);
+      if (format === "native") {
+        results = await validateNativeSteps(data, cache, "", expansionOpts);
+      } else {
+        results = await validateFormat2Steps(data, cache, "", expansionOpts);
+      }
     }
   } catch (e) {
     if (e instanceof Error && e.message.includes("legacy parameter encoding")) {
@@ -254,14 +300,19 @@ export async function operateValidate(
     }
   }
 
-  return buildSingleValidationReport(absPath, results, {
+  const report = buildSingleValidationReport(absPath, results, {
     structure_errors: structureErrors,
     encoding_errors: encodingErrors,
   });
+  if (clean_report !== null) {
+    (report as SingleValidationReport).clean_report = clean_report;
+  }
+  return report;
 }
 
 export interface LintOptions {
-  strict?: boolean;
+  strict_structure?: boolean;
+  strict_encoding?: boolean;
   /**
    * Tool IDs whose stale keys are allowed. Accepted for API parity; requires
    * StaleKeyPolicy (future work) — currently ignored.
@@ -281,9 +332,11 @@ export async function operateLint(
   opts: LintOptions = {},
 ): Promise<SingleLintReport> {
   const { absPath, data, format } = wf;
-  const strict = opts.strict
-    ? { strictEncoding: true, strictStructure: true, strictState: false }
-    : { strictEncoding: false, strictStructure: false, strictState: false };
+  const strict = {
+    strictEncoding: opts.strict_encoding ?? false,
+    strictStructure: opts.strict_structure ?? false,
+    strictState: false,
+  };
 
   const report = await lintWorkflowReport(absPath, data, format, { cache, strict });
 
@@ -319,16 +372,33 @@ export interface CleanOptions {
    * StaleKeyPolicy (future work) — currently ignored.
    */
   strip?: string[];
+  /** When true, populate before_content and after_content on the returned report. */
+  include_content?: boolean;
 }
 
 /** Report stale keys in a workflow (no tool cache needed). */
 export async function operateClean(
   wf: WorkflowFile,
-  _opts: CleanOptions = {},
+  opts: CleanOptions = {},
 ): Promise<SingleCleanReport> {
-  const { absPath, data } = wf;
-  const { results } = await cleanWorkflow(data);
-  return buildSingleCleanReport(absPath, results);
+  const { absPath, data, format } = wf;
+  const before_content = opts.include_content
+    ? format === "native"
+      ? JSON.stringify(data, null, 2)
+      : stringifyYaml(data)
+    : undefined;
+  const cleanResult = await cleanWorkflow(data);
+  const after_content = opts.include_content
+    ? format === "native"
+      ? JSON.stringify(cleanResult.workflow, null, 2)
+      : stringifyYaml(cleanResult.workflow)
+    : undefined;
+  const report = buildSingleCleanReport(absPath, cleanResult.results);
+  if (opts.include_content) {
+    (report as SingleCleanReport).before_content = before_content ?? null;
+    (report as SingleCleanReport).after_content = after_content ?? null;
+  }
+  return report;
 }
 
 /** Convert native → format2 with schema-aware state re-encoding. */
@@ -391,10 +461,18 @@ export async function operateToNative(wf: WorkflowFile, cache: ToolCache): Promi
   };
 }
 
+export interface RoundtripOptions {
+  strict_structure?: boolean;
+  strict_encoding?: boolean;
+  strict_state?: boolean;
+  include_content?: boolean;
+}
+
 /** Run roundtrip validation (native → format2 → native). */
 export async function operateRoundtrip(
   wf: WorkflowFile,
   cache: ToolCache,
+  opts: RoundtripOptions = {},
 ): Promise<SingleRoundTripReport> {
   const { absPath, data, format } = wf;
   if (format !== "native") {
@@ -405,7 +483,11 @@ export async function operateRoundtrip(
     resolver: createDefaultResolver({ workflowDirectory: path.dirname(absPath) }),
   };
   const { resolver } = await loadToolInputsForWorkflow(data, "native", cache, expansionOpts);
-  const result = roundtripValidate(data, resolver, {});
+  const result = roundtripValidate(data, resolver, {
+    strictStructure: opts.strict_structure,
+    strictEncoding: opts.strict_encoding,
+    strictState: opts.strict_state,
+  });
 
   // Convert TS-internal RoundtripResult → Python-API RoundTripValidationResult
   const allDiffs: StepDiff[] = result.stepResults.flatMap((s) => s.diffs);
@@ -462,7 +544,18 @@ export async function operateRoundtrip(
     summary_line: summaryLine,
   };
 
-  return { workflow: absPath, result: validationResult };
+  const before_content = opts.include_content ? JSON.stringify(data, null, 2) : undefined;
+  const after_content =
+    opts.include_content && result.reimportedWorkflow != null
+      ? JSON.stringify(result.reimportedWorkflow, null, 2)
+      : undefined;
+
+  return {
+    workflow: absPath,
+    result: validationResult,
+    before_content: before_content ?? null,
+    after_content: after_content ?? null,
+  };
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────

--- a/packages/schema/src/workflow/report-models.ts
+++ b/packages/schema/src/workflow/report-models.ts
@@ -96,6 +96,7 @@ export interface SingleValidationReport {
   structure_errors: string[];
   encoding_errors: string[];
   summary: { ok: number; fail: number; skip: number };
+  clean_report?: SingleCleanReport | null;
 }
 
 export interface SingleLintReport {
@@ -119,6 +120,8 @@ export interface SingleCleanReport {
   results: CleanStepResult[];
   total_removed: number;
   steps_with_removals: number;
+  before_content?: string | null;
+  after_content?: string | null;
 }
 
 // ── Round-trip validation types ──────────────────────────────────────
@@ -211,6 +214,8 @@ export interface RoundTripValidationResult {
 export interface SingleRoundTripReport {
   workflow: string;
   result: RoundTripValidationResult;
+  before_content?: string | null;
+  after_content?: string | null;
 }
 
 // ── Export / to-native types ─────────────────────────────────────────

--- a/packages/schema/src/workflow/roundtrip.ts
+++ b/packages/schema/src/workflow/roundtrip.ts
@@ -93,6 +93,12 @@ export interface RoundtripResult {
   encodingErrors: string[];
   /** Strict-structure errors across all stages (input, forward output, reverse output). */
   structureErrors: string[];
+  /**
+   * The re-imported native workflow dict (result of format2→native reverse pass).
+   * Only populated on successful roundtrip. Cast to Record<string, unknown> for
+   * serialization (same pattern as operateToNative in the server layer).
+   */
+  reimportedWorkflow?: unknown;
 }
 
 /** Options controlling strict validation within roundtripValidate. */
@@ -723,5 +729,6 @@ export function roundtripValidate(
     clean: !anyDiff && !anyError && !hasStrictErrors,
     encodingErrors,
     structureErrors,
+    reimportedWorkflow: reimported,
   };
 }


### PR DESCRIPTION
…ent to gxwf-web

- Fine-grained strict params (strict_structure, strict_encoding, strict_state) replace single strict bool on validate, lint, roundtrip
- clean_first option on validate: runs clean in-memory, embeds clean_report in response
- mode selector on validate: routes to AJV path when mode=json-schema
- include_content on clean/roundtrip: populates before_content/after_content on response
- RoundtripResult += reimportedWorkflow; SingleCleanReport/SingleRoundTripReport/SingleValidationReport extended with content/clean_report fields
- New decodeStructureErrorsJsonSchema export from cli
- openapi.json regenerated from Python FastAPI server; api-types.ts regenerated
- OperationPanel.vue: per-tab checkboxes/mode-select for all new options
- CleanReport/RoundtripReport/ValidationReport: collapsed content panels for before/after and clean_report