### PR TITLE
docs: publication guide + link all packages in changeset linked group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,10 @@
       "@galaxy-tool-util/schema",
       "@galaxy-tool-util/core",
       "@galaxy-tool-util/cli",
-      "@galaxy-tool-util/tool-cache-proxy"
+      "@galaxy-tool-util/tool-cache-proxy",
+      "@galaxy-tool-util/gxwf-web",
+      "@galaxy-tool-util/gxwf-client",
+      "@galaxy-tool-util/gxwf-report-shell"
     ]
   ],
   "access": "public",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Individual targets (e.g. `make sync-golden`, `make sync-param-spec`) are availab
 
 ## Releases
 
-Uses changesets with `@changesets/changelog-github`. All 4 packages version together (linked). Repo: `jmchilton/galaxy-tool-util-ts`.
+Uses changesets with `@changesets/changelog-github`. All published packages version together (linked). Repo: `jmchilton/galaxy-tool-util-ts`. See `docs/development/publication.md` for full details on how publication works and how to onboard new packages.
 
 **Changesets are required** for commits that affect published packages (`packages/*/src/`). When committing user-visible changes (features, fixes, API changes), include a changeset:
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -25,3 +25,4 @@
   - [Contributing](development/contributing.md)
   - [Testing](development/testing.md)
   - [Building](development/building.md)
+  - [Publication](development/publication.md)

--- a/docs/development/publication.md
+++ b/docs/development/publication.md
@@ -1,0 +1,93 @@
+# Publication
+
+## How It Works
+
+Releases are fully automated via the [changesets/action](https://github.com/changesets/action) GitHub Action on every push to `main`.
+
+### Flow
+
+1. During development, each PR that touches published package source includes a changeset file (created with `pnpm changeset`).
+2. On merge to `main`, the Action collects all pending `.changeset/*.md` files and opens a "Version Packages" PR that bumps versions and updates changelogs.
+3. When that PR is merged, the Action publishes all changed packages to npm using OIDC trusted publishing (no stored npm token — provenance is attached automatically via `NPM_CONFIG_PROVENANCE=true`).
+
+### Linked Versioning
+
+All published packages are in one linked group in `.changeset/config.json`:
+
+```json
+"linked": [
+  [
+    "@galaxy-tool-util/schema",
+    "@galaxy-tool-util/core",
+    "@galaxy-tool-util/cli",
+    "@galaxy-tool-util/tool-cache-proxy",
+    "@galaxy-tool-util/gxwf-web",
+    "@galaxy-tool-util/gxwf-client",
+    "@galaxy-tool-util/gxwf-report-shell"
+  ]
+]
+```
+
+Linked mode means: if any package bumps, **all linked packages bump to the same version** (taking the highest version in the group and applying the highest-level bump). This keeps versions in sync across the monorepo.
+
+Private packages (`gxwf-ui`, `gxwf-e2e`) are excluded from publishing automatically via `"private": true` in their `package.json`.
+
+### Trusted Publishing (OIDC)
+
+The release workflow uses GitHub Actions OIDC (`id-token: write`) instead of a stored npm token. This must be configured **per package** on npmjs.com:
+
+1. Go to `https://www.npmjs.com/package/<package-name>` → Settings → Trusted Publishers
+2. Add a trusted publisher: GitHub Actions, repo `jmchilton/galaxy-tool-util-ts`, workflow `release.yml`
+
+This configuration is already in place for all currently published packages.
+
+---
+
+## Adding a New Published Package
+
+New packages require a one-time manual stub publish to create the package page on npm before trusted publishing can be configured. Trusted publishing cannot be set up on a package that doesn't exist yet.
+
+### Step 1 — Temporarily set version to `0.0.0`
+
+Edit the new package's `package.json`:
+
+```json
+"version": "0.0.0"
+```
+
+### Step 2 — Build and publish the stub
+
+Ensure you're logged in to npm locally (`npm login`), then from the repo root:
+
+```bash
+pnpm build
+cd packages/<new-package>
+pnpm publish --no-git-checks --no-provenance --tag stub
+```
+
+Use `--no-provenance` because OIDC tokens aren't available locally. Use `--tag stub` so `0.0.0` doesn't become the `latest` tag.
+
+If npm prompts for 2FA, open the browser URL it provides to complete authentication.
+
+Publish packages in dependency order (if package B depends on package A via `workspace:*`, publish A first).
+
+### Step 3 — Restore the version
+
+Revert `package.json` back to the intended version (e.g. `0.1.0`). Do not commit the `0.0.0` change.
+
+### Step 4 — Configure trusted publishing on npmjs.com
+
+Go to `https://www.npmjs.com/package/@galaxy-tool-util/<new-package>` → Settings → Trusted Publishers and add:
+
+- **Provider**: GitHub Actions
+- **Repository**: `jmchilton/galaxy-tool-util-ts`
+- **Workflow**: `release.yml`
+- **Environment**: `npm-publish` (matches `environment: npm-publish` in `.github/workflows/release.yml`)
+
+### Step 5 — Add to the linked group
+
+Add the new package name to the `linked` array in `.changeset/config.json` (unless it should version independently).
+
+### Step 6 — Include in the changeset release
+
+Ensure a `.changeset/*.md` file references the new package so it appears in the next Version Packages PR.


### PR DESCRIPTION
- Add docs/development/publication.md covering release flow, OIDC trusted publishing, and stub-publish procedure for new packages
- Add gxwf-web, gxwf-client, gxwf-report-shell to linked versioning group
- Update CLAUDE.md to point at publication doc
- Add publication doc to sidebar