### PR TITLE
Add optional WorkflowOutput.type for plugin alignment

### DIFF
--- a/.changeset/workflow-output-type.md
+++ b/.changeset/workflow-output-type.md
@@ -1,0 +1,5 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+Add optional `type?: WorkflowDataType` to `WorkflowOutput`. Extractors leave it unset; downstream consumers (e.g. the VS Code plugin's AST extractor) populate it when the information is available.

--- a/packages/schema/src/test-format/cross-check/types.ts
+++ b/packages/schema/src/test-format/cross-check/types.ts
@@ -35,4 +35,5 @@ export interface WorkflowOutput {
   name: string;
   doc?: string;
   uuid?: string;
+  type?: WorkflowDataType;
 }


### PR DESCRIPTION
## Summary
- Add optional `type?: WorkflowDataType` to `WorkflowOutput` in the cross-check DTOs. Extractors leave it unset; downstream consumers (VS Code plugin's AST extractor) populate when the workflow format exposes it.
- Closes the last DTO-shape gap blocking the galaxy-workflows-vscode plugin from re-routing its `WorkflowOutput` through `@galaxy-tool-util/schema` (hover uses `output.type`).

## Test plan
- [x] `make check test` green locally.
- [ ] CI green.