### PR TITLE
Extract workflow-graph package from Galaxy editor

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,7 +14,8 @@
       "@galaxy-tool-util/tool-cache-proxy",
       "@galaxy-tool-util/gxwf-web",
       "@galaxy-tool-util/gxwf-client",
-      "@galaxy-tool-util/gxwf-report-shell"
+      "@galaxy-tool-util/gxwf-report-shell",
+      "@galaxy-tool-util/workflow-graph"
     ]
   ],
   "access": "public",

--- a/.changeset/workflow-graph-extract.md
+++ b/.changeset/workflow-graph-extract.md
@@ -1,0 +1,11 @@
+---
+"@galaxy-tool-util/workflow-graph": minor
+---
+
+Extract pure collection-type algebra (`CollectionTypeDescription`,
+`canMatch`/`canMapOver`/`append`/`effectiveMapOver`, `NULL`/`ANY` sentinels),
+multi-accept variant helpers (`canMatchAny`, `effectiveMapOverAny`),
+`DatatypesMapperModel`, and the `producesAcceptableDatatype`/
+`ConnectionAcceptable` datatype-compatibility predicate from Galaxy's
+workflow editor into a new standalone package. Zero behavior change versus
+the Galaxy source; Galaxy consumes this back as re-exports.

--- a/packages/workflow-graph/README.md
+++ b/packages/workflow-graph/README.md
@@ -1,0 +1,15 @@
+# @galaxy-tool-util/workflow-graph
+
+Pure collection-type algebra and datatype subtyping primitives extracted from Galaxy's workflow editor.
+
+Consumed by:
+
+- Galaxy (re-exported from `client/src/components/Workflow/Editor/modules/` and
+  `client/src/components/Datatypes/`).
+- The TypeScript workflow connection validator in this monorepo.
+- Future tooling (CLI, VS Code plugin, gxwf-ui).
+
+No runtime dependencies. Pure TypeScript / ESM.
+
+See `TS_CONNECTION_REFACTOR_IN_GX_PLAN.md` and the `old/CONNECTION_VALIDATION.md`
+historical note for context on why these primitives were extracted.

--- a/packages/workflow-graph/package.json
+++ b/packages/workflow-graph/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@galaxy-tool-util/workflow-graph",
+  "version": "0.1.0",
+  "description": "Pure collection-type algebra and datatype subtyping primitives extracted from Galaxy's workflow editor",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jmchilton/galaxy-tool-util-ts",
+    "directory": "packages/workflow-graph"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "tsc --noEmit && vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/ test/",
+    "format": "prettier --check 'src/**/*.ts' 'test/**/*.ts'",
+    "format-fix": "prettier --write 'src/**/*.ts' 'test/**/*.ts'"
+  },
+  "keywords": [
+    "galaxy",
+    "workflow",
+    "collection-type",
+    "datatypes"
+  ],
+  "license": "MIT"
+}

--- a/packages/workflow-graph/src/collection-type-variants.ts
+++ b/packages/workflow-graph/src/collection-type-variants.ts
@@ -1,0 +1,50 @@
+/**
+ * Variant-array helpers for multi-accept inputs.
+ *
+ * Galaxy tools can declare `collection_types: string[]` on collection inputs,
+ * meaning the input accepts any of several collection types. These helpers
+ * mirror the inner loop of `InputCollectionTerminal._effectiveMapOver` in the
+ * Galaxy editor and the Python port's `_split_collection_type` helper, minus
+ * the sample_sheet asymmetry guard (which belongs in caller-side decision
+ * logic — see D4 in the extraction plan).
+ */
+
+import type { CollectionTypeDescriptor } from "./collection-type.js";
+import { NULL_COLLECTION_TYPE_DESCRIPTION } from "./collection-type.js";
+
+/**
+ * True if `output`'s collection type matches any of the accepted `inputs`.
+ */
+export function canMatchAny(
+  output: CollectionTypeDescriptor,
+  inputs: CollectionTypeDescriptor[],
+): boolean {
+  return inputs.some((input) => input.canMatch(output));
+}
+
+/**
+ * Compute the effective map-over for an output connecting to a multi-accept
+ * input. Mirrors `InputCollectionTerminal._effectiveMapOver`:
+ * - If any accepted input directly matches the output, no map-over is needed
+ *   (returns NULL).
+ * - Otherwise, return the first non-null `output.effectiveMapOver(input)` for
+ *   an input the output can map over.
+ * - Falls back to NULL when no variant accepts the output.
+ */
+export function effectiveMapOverAny(
+  output: CollectionTypeDescriptor,
+  inputs: CollectionTypeDescriptor[],
+): CollectionTypeDescriptor {
+  if (inputs.some((input) => input.canMatch(output))) {
+    return NULL_COLLECTION_TYPE_DESCRIPTION;
+  }
+  for (const input of inputs) {
+    if (output.canMapOver(input)) {
+      const effective = output.effectiveMapOver(input);
+      if (effective !== NULL_COLLECTION_TYPE_DESCRIPTION) {
+        return effective;
+      }
+    }
+  }
+  return NULL_COLLECTION_TYPE_DESCRIPTION;
+}

--- a/packages/workflow-graph/src/collection-type.ts
+++ b/packages/workflow-graph/src/collection-type.ts
@@ -1,0 +1,237 @@
+/* classes for reasoning about collection map over state
+   null: not a collection?
+   NULL_COLLECTION_TYPE_DESCRIPTION: also not a collection. Is there any difference with null ?
+   ANY_COLLECTION_TYPE_DESCRIPTION: collection, but will never be mapped over (input has no collection_type)
+   CollectionTypeDescription: "normal" collection, with a `collection_type`
+*/
+
+export interface CollectionTypeDescriptor {
+  isCollection: boolean;
+  collectionType: string | null;
+  rank: number;
+  canMatch(other: CollectionTypeDescriptor): boolean;
+  canMapOver(other: CollectionTypeDescriptor): boolean;
+  append(other: CollectionTypeDescriptor): CollectionTypeDescriptor;
+  equal(other: CollectionTypeDescriptor | null): boolean;
+  toString(): string;
+  effectiveMapOver(other: CollectionTypeDescriptor): CollectionTypeDescriptor;
+}
+
+export const NULL_COLLECTION_TYPE_DESCRIPTION: CollectionTypeDescriptor = {
+  isCollection: false,
+  collectionType: null,
+  rank: 0,
+  canMatch: function (_other) {
+    return false;
+  },
+  canMapOver: function () {
+    return false;
+  },
+  toString: function () {
+    return "NullCollectionType[]";
+  },
+  append: function (other) {
+    return other;
+  },
+  equal: function (other) {
+    return other === this;
+  },
+  effectiveMapOver: function (_other: CollectionTypeDescriptor) {
+    return NULL_COLLECTION_TYPE_DESCRIPTION;
+  },
+};
+
+export const ANY_COLLECTION_TYPE_DESCRIPTION: CollectionTypeDescriptor = {
+  isCollection: true,
+  collectionType: "any",
+  rank: -1,
+  canMatch: function (other) {
+    return NULL_COLLECTION_TYPE_DESCRIPTION !== other;
+  },
+  canMapOver: function () {
+    return false;
+  },
+  toString: function () {
+    return "AnyCollectionType[]";
+  },
+  append: function () {
+    return ANY_COLLECTION_TYPE_DESCRIPTION;
+  },
+  equal: function (other) {
+    return other === this;
+  },
+  effectiveMapOver: function (_other: CollectionTypeDescriptor) {
+    return NULL_COLLECTION_TYPE_DESCRIPTION;
+  },
+};
+
+/**
+ * Normalize collection type for comparison purposes.
+ * sample_sheet behaves like list for mapping/matching.
+ */
+function normalizeCollectionType(collectionType: string): string {
+  if (collectionType.startsWith("sample_sheet")) {
+    return "list" + collectionType.slice("sample_sheet".length);
+  }
+  return collectionType;
+}
+
+export class CollectionTypeDescription implements CollectionTypeDescriptor {
+  collectionType: string;
+  isCollection: true;
+  rank: number;
+
+  constructor(collectionType: string) {
+    this.collectionType = collectionType;
+    this.isCollection = true;
+    this.rank = collectionType.split(":").length;
+  }
+  append(other: CollectionTypeDescriptor): CollectionTypeDescriptor {
+    if (other === NULL_COLLECTION_TYPE_DESCRIPTION) {
+      return this;
+    }
+    if (other === ANY_COLLECTION_TYPE_DESCRIPTION) {
+      return other;
+    }
+    return new CollectionTypeDescription(`${this.collectionType}:${other.collectionType}`);
+  }
+  canMatch(other: CollectionTypeDescriptor) {
+    const otherCollectionType = other.collectionType;
+    if (other === NULL_COLLECTION_TYPE_DESCRIPTION) {
+      return false;
+    }
+    if (other === ANY_COLLECTION_TYPE_DESCRIPTION) {
+      return true;
+    }
+    const normalizedThis = normalizeCollectionType(this.collectionType);
+    const normalizedOther = otherCollectionType
+      ? normalizeCollectionType(otherCollectionType)
+      : null;
+    if (normalizedOther === "paired" && normalizedThis == "paired_or_unpaired") {
+      return true;
+    }
+    if (normalizedThis.endsWith(":paired_or_unpaired")) {
+      const asPlainList = normalizedThis.slice(0, -":paired_or_unpaired".length);
+      if (normalizedOther === asPlainList) {
+        return true;
+      }
+      const asPairedList = `${asPlainList}:paired`;
+      if (normalizedOther === asPairedList) {
+        return true;
+      }
+    }
+    return normalizedOther == normalizedThis;
+  }
+  canMapOver(other: CollectionTypeDescriptor) {
+    if (!other.collectionType || other.collectionType === "any") {
+      return false;
+    }
+    const normalizedThis = normalizeCollectionType(this.collectionType);
+    const normalizedOther = normalizeCollectionType(other.collectionType);
+    if (this.rank <= other.rank) {
+      if (normalizedOther == "paired_or_unpaired") {
+        // this can be thought of as a subcollection of anything except a pair
+        // since it would match a pair exactly
+        return !normalizedThis.endsWith("paired");
+      }
+      if (normalizedOther.endsWith(":paired_or_unpaired")) {
+        return !normalizedThis.endsWith(":paired");
+      }
+      // Cannot map over self...
+      return false;
+    }
+    const requiredSuffix = normalizedOther;
+    const directMatch = this._endsWith(normalizedThis, `:${requiredSuffix}`);
+    if (directMatch) {
+      return true;
+    }
+    // this really needs to be extended to include anything suffixed with :paired_or_unpaired
+    if (requiredSuffix == "paired_or_unpaired") {
+      // anything can be mapped over this since it can always act a dataset
+      return true;
+    } else if (requiredSuffix.endsWith(":paired_or_unpaired")) {
+      const higherRanksRequired = requiredSuffix.substring(0, requiredSuffix.lastIndexOf(":"));
+      let higherRanks: string;
+      if (normalizedThis.endsWith(":paired")) {
+        higherRanks = normalizedThis.substring(0, normalizedThis.lastIndexOf(":"));
+      } else {
+        higherRanks = normalizedThis;
+      }
+      return this._endsWith(higherRanks, higherRanksRequired);
+    }
+    return false;
+  }
+  effectiveMapOver(other: CollectionTypeDescriptor): CollectionTypeDescriptor {
+    const thisCollectionType = this.collectionType;
+    if (other.collectionType && this.canMapOver(other)) {
+      const otherCollectionType = other.collectionType;
+      const normalizedThis = normalizeCollectionType(thisCollectionType);
+      const normalizedOther = normalizeCollectionType(otherCollectionType);
+      // needs to be extended to include ending in :paired_or_unpaired.
+      if (normalizedOther.endsWith("paired_or_unpaired")) {
+        if (normalizedOther == "paired_or_unpaired") {
+          if (normalizedThis.endsWith("list")) {
+            // the elements of the inner most list are consumed by the
+            // paired_or_unpaired input.
+            return new CollectionTypeDescription(thisCollectionType);
+          }
+          return new CollectionTypeDescription(
+            thisCollectionType.substring(0, thisCollectionType.lastIndexOf(":")),
+          );
+        } else if (normalizedThis.endsWith(":paired") || normalizedThis.endsWith(":list")) {
+          // otherCollectionType endswith :paired_or_unpaired
+          let currentCollectionType = thisCollectionType;
+          let currentOther = otherCollectionType;
+          while (currentOther.lastIndexOf(":") !== -1) {
+            currentOther = currentOther.substring(0, currentOther.lastIndexOf(":"));
+            currentCollectionType = currentCollectionType.substring(
+              0,
+              currentCollectionType.lastIndexOf(":"),
+            );
+          }
+          // and strip the last rank off for the remaining currentOther if
+          // the paired_or_unpaired consumed the inner paired collection
+          if (normalizedThis.endsWith(":paired")) {
+            currentCollectionType = currentCollectionType.substring(
+              0,
+              currentCollectionType.lastIndexOf(":"),
+            );
+          } else {
+            // this was a list so paired_or_unpaired will consume the datasets of the
+            // inner list and we can just stop here.
+          }
+          return new CollectionTypeDescription(currentCollectionType);
+        }
+      }
+      const effectiveCollectionType = thisCollectionType.substring(
+        0,
+        thisCollectionType.length - otherCollectionType.length - 1,
+      );
+      return new CollectionTypeDescription(effectiveCollectionType);
+    }
+    return NULL_COLLECTION_TYPE_DESCRIPTION;
+  }
+  equal(other: CollectionTypeDescriptor | null) {
+    if (!other) {
+      return false;
+    }
+    return other.collectionType == this.collectionType;
+  }
+  toString() {
+    return `CollectionType[${this.collectionType}]`;
+  }
+  _endsWith(str: string, suffix: string) {
+    return str.indexOf(suffix, str.length - suffix.length) !== -1;
+  }
+}
+
+const collectionTypeRegex =
+  /^((list|paired|paired_or_unpaired|record)(:(list|paired|paired_or_unpaired|record))*|sample_sheet|sample_sheet:paired|sample_sheet:record|sample_sheet:paired_or_unpaired)$/;
+
+export function isValidCollectionTypeStr(collectionType: string | undefined) {
+  if (collectionType) {
+    return collectionTypeRegex.test(collectionType);
+  } else {
+    return true;
+  }
+}

--- a/packages/workflow-graph/src/connection-acceptable.ts
+++ b/packages/workflow-graph/src/connection-acceptable.ts
@@ -1,0 +1,52 @@
+import type { DatatypesMapperModel } from "./datatypes-mapper.js";
+
+export class ConnectionAcceptable {
+  reason: string | null;
+  canAccept: boolean;
+  constructor(canAccept: boolean, reason: string | null) {
+    this.canAccept = canAccept;
+    this.reason = reason;
+  }
+}
+
+export function producesAcceptableDatatype(
+  datatypesMapper: DatatypesMapperModel,
+  inputDatatypes: string[],
+  otherDatatypes: string[],
+) {
+  for (const t in inputDatatypes) {
+    const thisDatatype = inputDatatypes[t]!;
+
+    if (thisDatatype === "input") {
+      return new ConnectionAcceptable(true, null);
+    }
+
+    // FIXME: No idea what to do about case when datatype is 'input'
+    const validMatch = otherDatatypes.some(
+      (otherDatatype) =>
+        otherDatatype === "input" ||
+        otherDatatype === "_sniff_" ||
+        datatypesMapper.isSubType(otherDatatype, thisDatatype),
+    );
+
+    if (validMatch) {
+      return new ConnectionAcceptable(true, null);
+    }
+  }
+  const datatypesSet = new Set(datatypesMapper.datatypes);
+  const invalidDatatypes = otherDatatypes.filter((datatype) => !datatypesSet.has(datatype));
+  if (invalidDatatypes.length) {
+    return new ConnectionAcceptable(
+      false,
+      `Effective output data type(s) [${invalidDatatypes.join(
+        ", ",
+      )}] unknown. This tool cannot be run on this Galaxy Server at this moment, please contact the Administrator.`,
+    );
+  }
+  return new ConnectionAcceptable(
+    false,
+    `Effective output data type(s) [${otherDatatypes.join(
+      ", ",
+    )}] do not appear to match input type(s) [${inputDatatypes.join(", ")}].`,
+  );
+}

--- a/packages/workflow-graph/src/datatypes-combined-map.ts
+++ b/packages/workflow-graph/src/datatypes-combined-map.ts
@@ -1,0 +1,16 @@
+/**
+ * Minimal hand-written equivalent of Galaxy's generated
+ * `components["schemas"]["DatatypesCombinedMap"]` type.
+ *
+ * Galaxy's canonical definition lives in the Pydantic model
+ * `DatatypesCombinedMap` under `lib/galaxy/schema/`. The Galaxy-side re-export
+ * site enforces structural compatibility at compile time, so drift would be
+ * caught loudly. See the extraction plan (D2) for the decision rationale.
+ */
+export interface DatatypesCombinedMap {
+  datatypes: string[];
+  datatypes_mapping: {
+    ext_to_class_name: Record<string, string>;
+    class_to_classes: Record<string, Record<string, boolean>>;
+  };
+}

--- a/packages/workflow-graph/src/datatypes-mapper.ts
+++ b/packages/workflow-graph/src/datatypes-mapper.ts
@@ -1,0 +1,46 @@
+import type { DatatypesCombinedMap } from "./datatypes-combined-map.js";
+
+export class DatatypesMapperModel {
+  datatypes: DatatypesCombinedMap["datatypes"];
+  datatypesMapping: DatatypesCombinedMap["datatypes_mapping"];
+
+  constructor(typesAndMapping: DatatypesCombinedMap) {
+    // create a shallow copy of the datatypes, otherwise sort mutates in place
+    // and causes a possible infinite render update loop.
+    this.datatypes = [...typesAndMapping.datatypes];
+    this.datatypes.sort();
+    this.datatypesMapping = typesAndMapping.datatypes_mapping;
+  }
+
+  /**
+   * Checks if a given child datatype is a subtype of a parent datatype.
+   * @param child - The child datatype extension as registered in the datatypes registry.
+   * @param parent - The parent datatype, which can be an extension or explicit class name
+   *                 Can also be used with extensionless abstract datatypes (e.g. "galaxy.datatypes.images.Image")
+   * @returns A boolean indicating whether the child is a subtype of the parent.
+   */
+  isSubType(child: string, parent: string): boolean {
+    const mapping = this.datatypesMapping;
+    const childClassName = mapping.ext_to_class_name[child];
+    const parentClassName = mapping.ext_to_class_name[parent] || parent;
+
+    if (!childClassName || !parentClassName) {
+      return false;
+    }
+    const childClassMappings = mapping.class_to_classes[childClassName];
+    if (!childClassMappings) {
+      return false;
+    }
+    return parentClassName in childClassMappings;
+  }
+
+  isSubTypeOfAny(child: string, parents: DatatypesCombinedMap["datatypes"]): boolean {
+    return parents.some((parent) => this.isSubType(child, parent));
+  }
+
+  /** For classes like `galaxy.datatypes.{parent}.{extension}`, get the extension's parent */
+  getParentDatatype(extension: string) {
+    const fullClassName = this.datatypesMapping.ext_to_class_name[extension];
+    return fullClassName?.split(".")[2];
+  }
+}

--- a/packages/workflow-graph/src/index.ts
+++ b/packages/workflow-graph/src/index.ts
@@ -1,0 +1,11 @@
+export {
+  ANY_COLLECTION_TYPE_DESCRIPTION,
+  CollectionTypeDescription,
+  NULL_COLLECTION_TYPE_DESCRIPTION,
+  isValidCollectionTypeStr,
+  type CollectionTypeDescriptor,
+} from "./collection-type.js";
+export { canMatchAny, effectiveMapOverAny } from "./collection-type-variants.js";
+export type { DatatypesCombinedMap } from "./datatypes-combined-map.js";
+export { DatatypesMapperModel } from "./datatypes-mapper.js";
+export { ConnectionAcceptable, producesAcceptableDatatype } from "./connection-acceptable.js";

--- a/packages/workflow-graph/test/collection-type-variants.test.ts
+++ b/packages/workflow-graph/test/collection-type-variants.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  CollectionTypeDescription,
+  NULL_COLLECTION_TYPE_DESCRIPTION,
+} from "../src/collection-type.js";
+import { canMatchAny, effectiveMapOverAny } from "../src/collection-type-variants.js";
+
+const listOrListPaired = [
+  new CollectionTypeDescription("list"),
+  new CollectionTypeDescription("list:paired"),
+];
+
+describe("canMatchAny", () => {
+  it("matches when the output matches any variant", () => {
+    expect(canMatchAny(new CollectionTypeDescription("list"), listOrListPaired)).toBe(true);
+    expect(canMatchAny(new CollectionTypeDescription("list:paired"), listOrListPaired)).toBe(true);
+  });
+
+  it("does not match when no variant matches", () => {
+    expect(canMatchAny(new CollectionTypeDescription("paired"), listOrListPaired)).toBe(false);
+  });
+});
+
+describe("effectiveMapOverAny", () => {
+  it("returns NULL when output already matches a variant", () => {
+    expect(effectiveMapOverAny(new CollectionTypeDescription("list"), listOrListPaired)).toBe(
+      NULL_COLLECTION_TYPE_DESCRIPTION,
+    );
+  });
+
+  it("finds a map-over via the first compatible variant", () => {
+    // list:list can map over list, yielding effective map-over "list".
+    const result = effectiveMapOverAny(
+      new CollectionTypeDescription("list:list"),
+      listOrListPaired,
+    );
+    expect(result.collectionType).toBe("list");
+  });
+
+  it("returns NULL when no variant accepts and none is mappable", () => {
+    expect(effectiveMapOverAny(new CollectionTypeDescription("paired"), listOrListPaired)).toBe(
+      NULL_COLLECTION_TYPE_DESCRIPTION,
+    );
+  });
+});

--- a/packages/workflow-graph/test/collection-type.test.ts
+++ b/packages/workflow-graph/test/collection-type.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ANY_COLLECTION_TYPE_DESCRIPTION,
+  CollectionTypeDescription,
+  NULL_COLLECTION_TYPE_DESCRIPTION,
+  isValidCollectionTypeStr,
+} from "../src/collection-type.js";
+
+describe("CollectionTypeDescription.canMatch", () => {
+  it("matches equal simple collection types", () => {
+    const list = new CollectionTypeDescription("list");
+    expect(list.canMatch(new CollectionTypeDescription("list"))).toBe(true);
+  });
+
+  it("does not match differing simple types", () => {
+    expect(
+      new CollectionTypeDescription("list").canMatch(new CollectionTypeDescription("paired")),
+    ).toBe(false);
+  });
+
+  it("matches equal compound types", () => {
+    expect(
+      new CollectionTypeDescription("list:paired").canMatch(
+        new CollectionTypeDescription("list:paired"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false vs NULL sentinel", () => {
+    expect(new CollectionTypeDescription("list").canMatch(NULL_COLLECTION_TYPE_DESCRIPTION)).toBe(
+      false,
+    );
+  });
+
+  it("returns true vs ANY sentinel", () => {
+    expect(new CollectionTypeDescription("list").canMatch(ANY_COLLECTION_TYPE_DESCRIPTION)).toBe(
+      true,
+    );
+  });
+
+  describe("paired_or_unpaired", () => {
+    it("accepts a paired collection as paired_or_unpaired", () => {
+      expect(
+        new CollectionTypeDescription("paired_or_unpaired").canMatch(
+          new CollectionTypeDescription("paired"),
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts a list at list:paired_or_unpaired", () => {
+      expect(
+        new CollectionTypeDescription("list:paired_or_unpaired").canMatch(
+          new CollectionTypeDescription("list"),
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts a list:paired at list:paired_or_unpaired", () => {
+      expect(
+        new CollectionTypeDescription("list:paired_or_unpaired").canMatch(
+          new CollectionTypeDescription("list:paired"),
+        ),
+      ).toBe(true);
+    });
+
+    it("does not accept list:list at list:paired_or_unpaired", () => {
+      expect(
+        new CollectionTypeDescription("list:paired_or_unpaired").canMatch(
+          new CollectionTypeDescription("list:list"),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("sample_sheet normalization", () => {
+    it("sample_sheet matches list (normalized)", () => {
+      expect(
+        new CollectionTypeDescription("list").canMatch(
+          new CollectionTypeDescription("sample_sheet"),
+        ),
+      ).toBe(true);
+    });
+
+    it("sample_sheet:paired matches list:paired (normalized)", () => {
+      expect(
+        new CollectionTypeDescription("list:paired").canMatch(
+          new CollectionTypeDescription("sample_sheet:paired"),
+        ),
+      ).toBe(true);
+    });
+
+    it("sample_sheet:paired_or_unpaired matches list:paired_or_unpaired", () => {
+      expect(
+        new CollectionTypeDescription("list:paired_or_unpaired").canMatch(
+          new CollectionTypeDescription("sample_sheet:paired_or_unpaired"),
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("CollectionTypeDescription.canMapOver", () => {
+  it("list can map over paired_or_unpaired (subcollection)", () => {
+    expect(
+      new CollectionTypeDescription("list").canMapOver(
+        new CollectionTypeDescription("paired_or_unpaired"),
+      ),
+    ).toBe(true);
+  });
+
+  it("list:paired can map over paired", () => {
+    expect(
+      new CollectionTypeDescription("list:paired").canMapOver(
+        new CollectionTypeDescription("paired"),
+      ),
+    ).toBe(true);
+  });
+
+  it("list cannot map over itself", () => {
+    expect(
+      new CollectionTypeDescription("list").canMapOver(new CollectionTypeDescription("list")),
+    ).toBe(false);
+  });
+
+  it("list:paired can map over paired_or_unpaired (universal suffix)", () => {
+    expect(
+      new CollectionTypeDescription("list:paired").canMapOver(
+        new CollectionTypeDescription("paired_or_unpaired"),
+      ),
+    ).toBe(true);
+  });
+
+  it("list:list:paired can map over list:paired_or_unpaired via compound suffix", () => {
+    expect(
+      new CollectionTypeDescription("list:list:paired").canMapOver(
+        new CollectionTypeDescription("list:paired_or_unpaired"),
+      ),
+    ).toBe(true);
+  });
+
+  it("refuses to map over ANY sentinel", () => {
+    expect(new CollectionTypeDescription("list").canMapOver(ANY_COLLECTION_TYPE_DESCRIPTION)).toBe(
+      false,
+    );
+  });
+});
+
+describe("CollectionTypeDescription.append", () => {
+  it("appends a normal collection type", () => {
+    const appended = new CollectionTypeDescription("list").append(
+      new CollectionTypeDescription("paired"),
+    );
+    expect(appended.collectionType).toBe("list:paired");
+  });
+
+  it("appending NULL yields this", () => {
+    const list = new CollectionTypeDescription("list");
+    expect(list.append(NULL_COLLECTION_TYPE_DESCRIPTION)).toBe(list);
+  });
+
+  it("appending ANY yields ANY", () => {
+    expect(new CollectionTypeDescription("list").append(ANY_COLLECTION_TYPE_DESCRIPTION)).toBe(
+      ANY_COLLECTION_TYPE_DESCRIPTION,
+    );
+  });
+});
+
+describe("CollectionTypeDescription.effectiveMapOver", () => {
+  it("strips matching suffix", () => {
+    const effective = new CollectionTypeDescription("list:paired").effectiveMapOver(
+      new CollectionTypeDescription("paired"),
+    );
+    expect(effective.collectionType).toBe("list");
+  });
+
+  it("returns NULL when not mappable", () => {
+    const effective = new CollectionTypeDescription("list").effectiveMapOver(
+      new CollectionTypeDescription("paired"),
+    );
+    expect(effective).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
+  });
+
+  it("list over paired_or_unpaired keeps the list rank", () => {
+    const effective = new CollectionTypeDescription("list").effectiveMapOver(
+      new CollectionTypeDescription("paired_or_unpaired"),
+    );
+    expect(effective.collectionType).toBe("list");
+  });
+
+  it("list:paired over paired_or_unpaired strips one rank", () => {
+    const effective = new CollectionTypeDescription("list:paired").effectiveMapOver(
+      new CollectionTypeDescription("paired_or_unpaired"),
+    );
+    expect(effective.collectionType).toBe("list");
+  });
+
+  it("list:list over list:paired_or_unpaired produces list", () => {
+    const effective = new CollectionTypeDescription("list:list").effectiveMapOver(
+      new CollectionTypeDescription("list:paired_or_unpaired"),
+    );
+    expect(effective.collectionType).toBe("list");
+  });
+});
+
+describe("sentinels", () => {
+  it("NULL does not match anything, including itself", () => {
+    expect(NULL_COLLECTION_TYPE_DESCRIPTION.canMatch(NULL_COLLECTION_TYPE_DESCRIPTION)).toBe(false);
+    expect(NULL_COLLECTION_TYPE_DESCRIPTION.canMatch(new CollectionTypeDescription("list"))).toBe(
+      false,
+    );
+  });
+
+  it("ANY matches any non-NULL", () => {
+    expect(ANY_COLLECTION_TYPE_DESCRIPTION.canMatch(new CollectionTypeDescription("list"))).toBe(
+      true,
+    );
+    expect(ANY_COLLECTION_TYPE_DESCRIPTION.canMatch(NULL_COLLECTION_TYPE_DESCRIPTION)).toBe(false);
+  });
+
+  it("NULL.append(other) returns other", () => {
+    const list = new CollectionTypeDescription("list");
+    expect(NULL_COLLECTION_TYPE_DESCRIPTION.append(list)).toBe(list);
+  });
+
+  it("ANY.append always returns ANY", () => {
+    expect(ANY_COLLECTION_TYPE_DESCRIPTION.append(new CollectionTypeDescription("list"))).toBe(
+      ANY_COLLECTION_TYPE_DESCRIPTION,
+    );
+  });
+
+  it("equal is reference-based on sentinels", () => {
+    expect(NULL_COLLECTION_TYPE_DESCRIPTION.equal(NULL_COLLECTION_TYPE_DESCRIPTION)).toBe(true);
+    expect(NULL_COLLECTION_TYPE_DESCRIPTION.equal(ANY_COLLECTION_TYPE_DESCRIPTION)).toBe(false);
+    expect(ANY_COLLECTION_TYPE_DESCRIPTION.equal(ANY_COLLECTION_TYPE_DESCRIPTION)).toBe(true);
+  });
+});
+
+describe("isValidCollectionTypeStr", () => {
+  it("accepts simple and compound types", () => {
+    expect(isValidCollectionTypeStr("list")).toBe(true);
+    expect(isValidCollectionTypeStr("list:paired")).toBe(true);
+    expect(isValidCollectionTypeStr("list:list:paired")).toBe(true);
+  });
+
+  it("accepts sample_sheet variants", () => {
+    expect(isValidCollectionTypeStr("sample_sheet")).toBe(true);
+    expect(isValidCollectionTypeStr("sample_sheet:paired")).toBe(true);
+    expect(isValidCollectionTypeStr("sample_sheet:paired_or_unpaired")).toBe(true);
+  });
+
+  it("rejects unknown element types", () => {
+    expect(isValidCollectionTypeStr("bogus")).toBe(false);
+    expect(isValidCollectionTypeStr("list:bogus")).toBe(false);
+  });
+
+  it("treats empty / undefined as valid", () => {
+    expect(isValidCollectionTypeStr(undefined)).toBe(true);
+    expect(isValidCollectionTypeStr("")).toBe(true);
+  });
+});

--- a/packages/workflow-graph/test/datatypes-mapper.test.ts
+++ b/packages/workflow-graph/test/datatypes-mapper.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { DatatypesMapperModel } from "../src/datatypes-mapper.js";
+import { testDatatypesMapper, testTypesAndMapping } from "./fixtures.js";
+
+describe("DatatypesMapperModel", () => {
+  it("resolves subtype relationships through extension mappings", () => {
+    expect(testDatatypesMapper.isSubType("txt", "data")).toBe(true);
+    expect(testDatatypesMapper.isSubType("txt", "txt")).toBe(true);
+    expect(testDatatypesMapper.isSubType("data", "txt")).toBe(false);
+  });
+
+  it("supports subtype check against a list of parents", () => {
+    expect(testDatatypesMapper.isSubTypeOfAny("data", ["txt", "data"])).toBe(true);
+    expect(testDatatypesMapper.isSubTypeOfAny("tabular", ["binary"])).toBe(false);
+    expect(testDatatypesMapper.isSubTypeOfAny("tabular", ["binary", "txt"])).toBe(true);
+  });
+
+  it("allows parents given as explicit class names", () => {
+    expect(testDatatypesMapper.isSubType("txt", "Data")).toBe(true);
+    expect(testDatatypesMapper.isSubType("txt", "Binary")).toBe(false);
+  });
+
+  it("returns false for unknown child datatypes", () => {
+    expect(testDatatypesMapper.isSubType("nonexistent", "data")).toBe(false);
+  });
+
+  it("returns false for unknown parent extension that is also not a class", () => {
+    expect(testDatatypesMapper.isSubType("txt", "")).toBe(false);
+  });
+
+  it("sorts datatypes without mutating the caller's array", () => {
+    const input = { ...testTypesAndMapping, datatypes: ["zzz", "aaa", "mmm"] };
+    const before = [...input.datatypes];
+    const mapper = new DatatypesMapperModel(input);
+    expect(mapper.datatypes).toEqual(["aaa", "mmm", "zzz"]);
+    expect(input.datatypes).toEqual(before);
+  });
+});

--- a/packages/workflow-graph/test/fixtures.ts
+++ b/packages/workflow-graph/test/fixtures.ts
@@ -1,0 +1,12 @@
+import DatatypesJson from "./fixtures/datatypes.json" with { type: "json" };
+import DatatypesMappingJson from "./fixtures/datatypes.mapping.json" with { type: "json" };
+
+import type { DatatypesCombinedMap } from "../src/datatypes-combined-map.js";
+import { DatatypesMapperModel } from "../src/datatypes-mapper.js";
+
+export const testTypesAndMapping: DatatypesCombinedMap = {
+  datatypes: DatatypesJson,
+  datatypes_mapping: DatatypesMappingJson,
+};
+
+export const testDatatypesMapper = new DatatypesMapperModel(testTypesAndMapping);

--- a/packages/workflow-graph/test/fixtures/datatypes.json
+++ b/packages/workflow-graph/test/fixtures/datatypes.json
@@ -1,0 +1,7 @@
+[
+    "RData",
+    "ab1",
+    "affybatch",
+    "txt",
+    "tabular"
+]

--- a/packages/workflow-graph/test/fixtures/datatypes.mapping.json
+++ b/packages/workflow-graph/test/fixtures/datatypes.mapping.json
@@ -1,0 +1,32 @@
+{
+    "ext_to_class_name": {
+        "txt": "Text",
+        "data": "Data",
+        "tabular": "Tabular",
+        "binary": "Binary",
+        "bam": "Bam"
+    },
+    "class_to_classes": {
+        "Data": {
+            "Data": true
+        },
+        "Text": {
+            "Text": true,
+            "Data": true
+        },
+        "Tabular": {
+            "Tabular": true,
+            "Text": true,
+            "Data": true
+        },
+        "Binary": {
+            "Data": true,
+            "Binary": true
+        },
+        "Bam": {
+            "Data": true,
+            "Binary": true,
+            "Bam": true
+        }
+    }
+}

--- a/packages/workflow-graph/test/produces-acceptable-datatype.test.ts
+++ b/packages/workflow-graph/test/produces-acceptable-datatype.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { ConnectionAcceptable, producesAcceptableDatatype } from "../src/connection-acceptable.js";
+import { testDatatypesMapper } from "./fixtures.js";
+
+describe("producesAcceptableDatatype", () => {
+  it("accepts exact datatype match", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["txt"], ["txt"]);
+    expect(result).toBeInstanceOf(ConnectionAcceptable);
+    expect(result.canAccept).toBe(true);
+    expect(result.reason).toBeNull();
+  });
+
+  it("accepts subtype match (txt is a subtype of data)", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["data"], ["txt"]);
+    expect(result.canAccept).toBe(true);
+  });
+
+  it("accepts when input datatype is 'input' wildcard", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["input"], ["whatever"]);
+    expect(result.canAccept).toBe(true);
+  });
+
+  it("accepts when other datatype is 'input' wildcard", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["txt"], ["input"]);
+    expect(result.canAccept).toBe(true);
+  });
+
+  it("accepts when other datatype is '_sniff_' wildcard", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["txt"], ["_sniff_"]);
+    expect(result.canAccept).toBe(true);
+  });
+
+  it("rejects incompatible known datatypes with a mismatch message", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["tabular"], ["ab1"]);
+    expect(result.canAccept).toBe(false);
+    expect(result.reason).toMatch(/do not appear to match/);
+    expect(result.reason).toMatch(/ab1/);
+    expect(result.reason).toMatch(/tabular/);
+  });
+
+  it("rejects unknown output datatypes with an 'unknown' message", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["txt"], ["bogus_ext"]);
+    expect(result.canAccept).toBe(false);
+    expect(result.reason).toMatch(/unknown/);
+    expect(result.reason).toMatch(/bogus_ext/);
+  });
+
+  it("accepts when any one of multiple input types matches", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["ab1", "data"], ["txt"]);
+    expect(result.canAccept).toBe(true);
+  });
+
+  it("accepts when any one of multiple output types matches an input type", () => {
+    const result = producesAcceptableDatatype(testDatatypesMapper, ["data"], ["ab1", "txt"]);
+    expect(result.canAccept).toBe(true);
+  });
+});
+
+describe("ConnectionAcceptable", () => {
+  it("stores canAccept and reason", () => {
+    const ok = new ConnectionAcceptable(true, null);
+    expect(ok.canAccept).toBe(true);
+    expect(ok.reason).toBeNull();
+    const no = new ConnectionAcceptable(false, "nope");
+    expect(no.canAccept).toBe(false);
+    expect(no.reason).toBe("nope");
+  });
+});

--- a/packages/workflow-graph/tsconfig.json
+++ b/packages/workflow-graph/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/workflow-graph/vitest.config.ts
+++ b/packages/workflow-graph/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+  test: {
+    include: ["test/**/*.test.ts"],
+    globals: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,8 @@ importers:
         specifier: ^25.5.0
         version: 25.5.0
 
+  packages/workflow-graph: {}
+
 packages:
 
   '@andrewbranch/untar.js@1.0.3':


### PR DESCRIPTION
New @galaxy-tool-util/workflow-graph with collection-type algebra (CollectionTypeDescription, NULL/ANY sentinels, canMatchAny, effectiveMapOverAny), DatatypesMapperModel, and the producesAcceptableDatatype/ConnectionAcceptable predicate. Ports verbatim from client/src/components/Workflow/Editor/modules/ and Datatypes/ with no behavior changes per plan D1. Hand-written minimal DatatypesCombinedMap (D2). Galaxy-side adoption happens in a follow-up PR.