### PR TITLE
Restructure docs/skills/ into per-skill directories

### DIFF
--- a/.changeset/skills-dir-restructure.md
+++ b/.changeset/skills-dir-restructure.md
@@ -1,0 +1,4 @@
+---
+---
+
+Move generated CLI skill to `docs/skills/gxwf-cli/SKILL.md` (per-skill directory layout).

--- a/.claude/skills/gen-gxwf-cli-skill/SKILL.md
+++ b/.claude/skills/gen-gxwf-cli-skill/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: gen-gxwf-cli-skill
-description: Regenerate the single-page gxwf / galaxy-tool-cache CLI skill at docs/skills/gxwf-cli.skill.md. Use after CLI churn — runs `make gen-skill` (commander introspection) then enriches the generated scaffold with worked examples and exit-code prose lifted from docs/packages/cli.md.
+description: Regenerate the single-page gxwf / galaxy-tool-cache CLI skill at docs/skills/gxwf-cli/SKILL.md. Use after CLI churn — runs `make gen-skill` (commander introspection) then enriches the generated scaffold with worked examples and exit-code prose lifted from docs/packages/cli.md.
 argument-hint: "[--check]"
 user-invocable: true
 ---
 
 # Generate gxwf-cli skill
 
-Regenerates `docs/skills/gxwf-cli.skill.md` — a single-file, distributable skill
+Regenerates `docs/skills/gxwf-cli/SKILL.md` — a single-file, distributable skill
 covering the surface of both `gxwf` and `galaxy-tool-cache`.
 
 ## Why this skill exists
@@ -27,7 +27,7 @@ files you already maintain.
 ## Steps
 
 1. Run `make gen-skill`. This builds `@galaxy-tool-util/cli` (the generator
-   imports from `dist/`) and writes a fresh `docs/skills/gxwf-cli.skill.md`.
+   imports from `dist/`) and writes a fresh `docs/skills/gxwf-cli/SKILL.md`.
    Treat its frontmatter, command/option tables, and argument lists as
    authoritative — never hand-edit them. If they look wrong, fix the source
    in `packages/cli/src/programs/` and re-run.
@@ -68,7 +68,7 @@ files you already maintain.
   the output — re-run `make gen-skill` and fix the source.
 - Never invent options, flags, or examples not present in
   `packages/cli/src/programs/` or `docs/packages/cli.md`.
-- The skill output lives at `docs/skills/gxwf-cli.skill.md`. Do not move it.
+- The skill output lives at `docs/skills/gxwf-cli/SKILL.md`. Do not move it.
 
 ## Files involved
 
@@ -77,4 +77,4 @@ files you already maintain.
   program definition
 - `packages/cli/scripts/generate-cli-skill.mjs` — introspection generator
 - `docs/packages/cli.md` — prose source (examples, exit codes, narrative)
-- `docs/skills/gxwf-cli.skill.md` — generated output
+- `docs/skills/gxwf-cli/SKILL.md` — generated output

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check: lint format typecheck verify-test-format-schema
 fix: format-fix
 	pnpm -r lint -- --fix
 
-# Regenerate docs/skills/gxwf-cli.skill.md from the commander program definitions.
+# Regenerate docs/skills/gxwf-cli/SKILL.md from the commander program definitions.
 # Builds @galaxy-tool-util/cli first since the generator imports from dist/.
 gen-skill:
 	pnpm --filter @galaxy-tool-util/cli build

--- a/docs/skills/gxwf-cli/SKILL.md
+++ b/docs/skills/gxwf-cli/SKILL.md
@@ -264,6 +264,69 @@ Batch validate workflow-test files (*-tests.yml / *.gxwf-tests.yml) under a dire
 | `--json` | Output structured JSON report |
 | `--auto-workflow` | Pair each tests file with a sibling workflow by filename convention (foo.gxwf-tests.yml ↔ foo.gxwf.yml/foo.ga) and cross-check inputs/outputs |
 
+### `tool-search <query>`
+
+Search the Galaxy Tool Shed for tools matching a query
+
+**Arguments:**
+
+- `<query>` — Search text (e.g. 'fastqc')
+
+| Option | Description |
+|---|---|
+| `--page-size <n>` | Server-side page size (default: `20`) |
+| `--max-results <n>` | Hard cap on hits returned (default: `50`) |
+| `--page <n>` | Starting page (1-indexed) (default: `1`) |
+| `--owner <user>` | Filter hits to a single repo owner (client-side) |
+| `--match-name` | Drop hits where the query is not a token in the tool name |
+| `--json` | Emit machine-readable JSON envelope |
+| `--enrich` | Resolve each hit's ParsedTool and attach it as `parsedTool` (one fetch per hit; off by default) |
+| `--cache-dir <dir>` | Tool cache directory (used by --enrich; shared with galaxy-tool-cache) |
+
+### `tool-versions <tool-id>`
+
+List TRS-published versions of a Tool Shed tool (newest last)
+
+**Arguments:**
+
+- `<tool-id>` — TRS id (owner~repo~tool_id) or pretty form (owner/repo/tool_id)
+
+| Option | Description |
+|---|---|
+| `--json` | Emit machine-readable JSON envelope |
+| `--latest` | Print only the latest version |
+
+### `tool-revisions <tool-id>`
+
+List changeset revisions that publish a Tool Shed tool (ordered oldest→newest). Use for reproducible (name, owner, changeset_revision) workflow pins. Caveat: version strings are not monotonic — the same version can appear in multiple changesets.
+
+**Arguments:**
+
+- `<tool-id>` — TRS id (owner~repo~tool_id) or pretty form (owner/repo/tool_id)
+
+| Option | Description |
+|---|---|
+| `--tool-version <v>` | Restrict to revisions that publish this exact tool version |
+| `--latest` | Print only the newest matching revision |
+| `--json` | Emit machine-readable JSON envelope |
+
+### `repo-search <query>`
+
+Search the Galaxy Tool Shed for repositories. Ranking is popularity-boosted; supports server-side --owner / --category filters via reserved keywords.
+
+**Arguments:**
+
+- `<query>` — Search text (e.g. 'fastqc')
+
+| Option | Description |
+|---|---|
+| `--page-size <n>` | Server-side page size (default: `20`) |
+| `--max-results <n>` | Hard cap on hits returned (default: `50`) |
+| `--page <n>` | Starting page (1-indexed) (default: `1`) |
+| `--owner <user>` | Restrict to a single owner (server-side `owner:` keyword) |
+| `--category <name>` | Restrict to a category (server-side `category:` keyword) |
+| `--json` | Emit machine-readable JSON envelope |
+
 ## `galaxy-tool-cache`
 
 Cache and inspect Galaxy tool metadata

--- a/packages/cli/scripts/generate-cli-skill.mjs
+++ b/packages/cli/scripts/generate-cli-skill.mjs
@@ -1,5 +1,5 @@
 /**
- * Generate docs/skills/gxwf-cli.skill.md from commander programs.
+ * Generate docs/skills/gxwf-cli/SKILL.md from commander programs.
  *
  * Walks the configured Command instances for `gxwf` and `galaxy-tool-cache`
  * and emits a single distributable skill markdown file. Re-run after CLI churn.
@@ -16,7 +16,7 @@ import { buildGalaxyToolCacheProgram } from "../dist/programs/galaxy-tool-cache.
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "../../..");
-const outFile = join(repoRoot, "docs/skills/gxwf-cli.skill.md");
+const outFile = join(repoRoot, "docs/skills/gxwf-cli/SKILL.md");
 
 const FRONTMATTER = `---
 name: gxwf-cli


### PR DESCRIPTION
## Summary

- Move `docs/skills/gxwf-cli.skill.md` → `docs/skills/gxwf-cli/SKILL.md` so each skill owns a directory (room for assets, examples, sub-files as more skills are added).
- Update output path in `packages/cli/scripts/generate-cli-skill.mjs`, Makefile comment, and the three references in `.claude/skills/gen-gxwf-cli-skill/SKILL.md`.
- Empty changeset — no published-package surface change.

Follow-up to #73.

## Test plan

- [x] `make gen-skill` writes to the new location
- [x] `git mv` preserves history (rename detected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)