### PR TITLE
core: cache-inspection primitives on ToolCache + CacheStorage

### DIFF
--- a/.changeset/cache-inspection-primitives.md
+++ b/.changeset/cache-inspection-primitives.md
@@ -1,0 +1,11 @@
+---
+"@galaxy-tool-util/core": minor
+---
+
+Add cache-inspection primitives on `ToolCache` and `CacheStorage`:
+
+- `ToolCache.removeCached(key)` — delete a single cached entry by cache key.
+- `ToolCache.loadCachedRaw(key)` — read the raw cached payload without `ParsedTool` decoding, for inspecting stale or partial entries.
+- `ToolCache.getCacheStats()` — aggregate counts, total bytes, source breakdown, and oldest/newest timestamps.
+- Optional `CacheStorage.stat?(key)` — per-entry size (and mtime on filesystem). Implemented on `FilesystemCacheStorage` and `IndexedDBCacheStorage`.
+- Lazy-index backfill in `loadCached` now records the version off the decoded `ParsedTool` and tags the source as `"orphan"` so reconstructed entries are flagged.

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -4,7 +4,7 @@ export { cacheKey } from "./cache-key.js";
 export { CacheIndex } from "./cache-index.js";
 export type { CacheIndexEntry, CacheIndexData } from "./cache-index.js";
 export { ToolCache } from "./tool-cache.js";
-export type { ResolvedCoordinates } from "./tool-cache.js";
+export type { ResolvedCoordinates, CacheStats } from "./tool-cache.js";
 export { DEFAULT_TOOLSHED_URL, TOOLSHED_URL_ENV_VAR } from "./tool-cache-defaults.js";
 export type { CacheStorage } from "./storage/interface.js";
 export { IndexedDBCacheStorage } from "./storage/indexeddb.js";

--- a/packages/core/src/cache/storage/filesystem.ts
+++ b/packages/core/src/cache/storage/filesystem.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, unlink, readdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, unlink, readdir, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -51,6 +51,17 @@ export class FilesystemCacheStorage implements CacheStorage {
     return files
       .filter((f) => f.endsWith(".json") && f !== INDEX_FILENAME)
       .map((f) => f.slice(0, -5));
+  }
+
+  async stat(key: string): Promise<{ sizeBytes: number; mtime?: string } | null> {
+    const path = this.keyToPath(key);
+    if (!existsSync(path)) return null;
+    try {
+      const s = await stat(path);
+      return { sizeBytes: s.size, mtime: s.mtime.toISOString() };
+    } catch {
+      return null;
+    }
   }
 
   async saveAll(entries: ReadonlyArray<[string, unknown]>): Promise<void> {

--- a/packages/core/src/cache/storage/indexeddb.ts
+++ b/packages/core/src/cache/storage/indexeddb.ts
@@ -77,6 +77,18 @@ export class IndexedDBCacheStorage implements CacheStorage {
     });
   }
 
+  async stat(key: string): Promise<{ sizeBytes: number; mtime?: string } | null> {
+    const value = await this.load(key);
+    if (value === null) return null;
+    let sizeBytes: number;
+    if (value instanceof Blob) {
+      sizeBytes = value.size;
+    } else {
+      sizeBytes = JSON.stringify(value).length;
+    }
+    return { sizeBytes };
+  }
+
   /** Bulk insert using a single transaction — efficient for pre-populating from a bundled dataset. */
   async saveAll(entries: ReadonlyArray<[string, unknown]>): Promise<void> {
     const db = await this.getDb();

--- a/packages/core/src/cache/storage/interface.ts
+++ b/packages/core/src/cache/storage/interface.ts
@@ -13,4 +13,6 @@ export interface CacheStorage {
   list(): Promise<string[]>;
   /** Optional bulk insert — single transaction for efficiency (e.g. pre-populating from bundle). */
   saveAll?(entries: ReadonlyArray<[string, unknown]>): Promise<void>;
+  /** Optional per-entry size/mtime metadata. Returns null if the key is missing. */
+  stat?(key: string): Promise<{ sizeBytes: number; mtime?: string } | null>;
 }

--- a/packages/core/src/cache/tool-cache.ts
+++ b/packages/core/src/cache/tool-cache.ts
@@ -16,6 +16,17 @@ function envToolshedUrl(): string | undefined {
   return undefined;
 }
 
+export interface CacheStats {
+  count: number;
+  /** Omitted if the storage backend does not implement `stat()`. */
+  totalBytes?: number;
+  bySource: Record<string, number>;
+  /** ISO 8601 timestamp of the oldest entry's `cached_at`. */
+  oldest?: string;
+  /** ISO 8601 timestamp of the newest entry's `cached_at`. */
+  newest?: string;
+}
+
 export interface ResolvedCoordinates {
   toolshedUrl: string;
   trsToolId: string;
@@ -77,8 +88,13 @@ export class ToolCache {
       if (data === null) return null;
       const parsedTool = S.decodeUnknownSync(ParsedTool)(data);
       if (!(await this.index.has(key))) {
-        const d = data as { id?: string; version?: string };
-        await this.index.add(key, d.id ?? "unknown", d.version ?? "unknown", "unknown");
+        const d = data as { id?: string };
+        await this.index.add(
+          key,
+          d.id ?? parsedTool.id ?? "unknown",
+          parsedTool.version ?? "unknown",
+          "orphan",
+        );
       }
       this.memoryCache.set(key, parsedTool);
       return parsedTool;
@@ -86,6 +102,29 @@ export class ToolCache {
       console.debug(`Failed to load cached tool ${key}: ${err}`);
       return null;
     }
+  }
+
+  /**
+   * Load the raw cached payload without ParsedTool decoding.
+   * Returns null only if the key is missing — surfaces stale or malformed entries
+   * the inspector needs to render explicitly.
+   */
+  async loadCachedRaw(key: string): Promise<unknown | null> {
+    return this.storage.load(key);
+  }
+
+  /**
+   * Remove a single cached entry by cache key. Returns true if anything was
+   * removed (storage or index), false if neither held the key.
+   */
+  async removeCached(key: string): Promise<boolean> {
+    const inIndex = await this.index.has(key);
+    const inStorage = inIndex ? false : (await this.storage.list()).includes(key);
+    const existed = inIndex || inStorage;
+    await this.storage.delete(key);
+    await this.index.remove(key);
+    this.memoryCache.delete(key);
+    return existed;
   }
 
   async saveTool(
@@ -112,6 +151,30 @@ export class ToolCache {
     }>
   > {
     return this.index.listAll();
+  }
+
+  async getCacheStats(): Promise<CacheStats> {
+    const entries = await this.index.listAll();
+    const bySource: Record<string, number> = {};
+    let oldest: string | undefined;
+    let newest: string | undefined;
+    for (const e of entries) {
+      bySource[e.source] = (bySource[e.source] ?? 0) + 1;
+      if (oldest === undefined || e.cached_at < oldest) oldest = e.cached_at;
+      if (newest === undefined || e.cached_at > newest) newest = e.cached_at;
+    }
+    const stats: CacheStats = { count: entries.length, bySource };
+    if (oldest !== undefined) stats.oldest = oldest;
+    if (newest !== undefined) stats.newest = newest;
+    if (typeof this.storage.stat === "function") {
+      let totalBytes = 0;
+      for (const e of entries) {
+        const s = await this.storage.stat(e.cache_key);
+        if (s !== null) totalBytes += s.sizeBytes;
+      }
+      stats.totalBytes = totalBytes;
+    }
+    return stats;
   }
 
   async clearCache(toolIdPrefix?: string): Promise<void> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   CacheIndexData,
   CacheStorage,
   ResolvedCoordinates,
+  CacheStats,
 } from "./cache/index.js";
 /** IndexedDB-backed cache storage for browser/Web Worker contexts. */
 export { IndexedDBCacheStorage } from "./cache/index.js";

--- a/packages/core/test/cache-indexeddb.browser.test.ts
+++ b/packages/core/test/cache-indexeddb.browser.test.ts
@@ -57,6 +57,14 @@ describe("IndexedDBCacheStorage (browser)", () => {
     await storage.delete("gone");
     expect(await storage.load("gone")).toBeNull();
   });
+
+  it("stat returns sizeBytes for stored values", async () => {
+    await storage.save("size1", { hello: "world" });
+    const s = await storage.stat("size1");
+    expect(s).not.toBeNull();
+    expect(s!.sizeBytes).toBeGreaterThan(0);
+    expect(await storage.stat("missing")).toBeNull();
+  });
 });
 
 describe("ToolCache with IndexedDBCacheStorage (browser)", () => {

--- a/packages/core/test/cache.test.ts
+++ b/packages/core/test/cache.test.ts
@@ -253,6 +253,102 @@ describe("ToolCache", () => {
     expect(coords.version).toBeNull();
   });
 
+  it("removeCached deletes one entry by cache key", async () => {
+    await cache.saveTool("k1", sampleTool, "tool1", "1.0", "api");
+    await cache.saveTool("k2", sampleTool, "tool2", "2.0", "api");
+    expect(await cache.removeCached("k1")).toBe(true);
+    const remaining = await cache.listCached();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].cache_key).toBe("k2");
+    expect(await cache.loadCached("k1")).toBeNull();
+  });
+
+  it("removeCached returns false for unknown key", async () => {
+    expect(await cache.removeCached("nope")).toBe(false);
+  });
+
+  it("removeCached returns true for orphan-only entry (storage but no index)", async () => {
+    await writeFile(join(tmpDir, "orphan.json"), JSON.stringify(sampleTool));
+    expect(await cache.removeCached("orphan")).toBe(true);
+    expect(await cache.loadCachedRaw("orphan")).toBeNull();
+  });
+
+  it("removeCached returns true for index-only entry (index but no storage)", async () => {
+    await cache.index.add("ghost", "tool/id", "1.0", "api");
+    expect(await cache.removeCached("ghost")).toBe(true);
+    expect(await cache.index.has("ghost")).toBe(false);
+  });
+
+  it("loadCachedRaw returns undecoded payload that fails ParsedTool decode", async () => {
+    const malformed = { id: "x", legacy: true, version: 42 };
+    await writeFile(join(tmpDir, "stale.json"), JSON.stringify(malformed));
+    expect(await cache.loadCached("stale")).toBeNull();
+    const raw = (await cache.loadCachedRaw("stale")) as typeof malformed;
+    expect(raw).not.toBeNull();
+    expect(raw.id).toBe("x");
+    expect(raw.legacy).toBe(true);
+    expect(raw.version).toBe(42);
+  });
+
+  it("loadCachedRaw returns null for missing key", async () => {
+    expect(await cache.loadCachedRaw("missing")).toBeNull();
+  });
+
+  it("lazy-index backfill marks orphan entries", async () => {
+    const key = "orphan1";
+    await writeFile(join(tmpDir, `${key}.json`), JSON.stringify(sampleTool));
+    const loaded = await cache.loadCached(key);
+    expect(loaded).not.toBeNull();
+    const entry = (await cache.listCached()).find((e) => e.cache_key === key);
+    expect(entry).toBeDefined();
+    expect(entry!.source).toBe("orphan");
+    expect(entry!.tool_version).toBe("0.74+galaxy0");
+    expect(entry!.tool_id).toBe("fastqc");
+  });
+
+  it("getCacheStats aggregates counts, sources, totals, and timestamps", async () => {
+    await cache.saveTool("k1", sampleTool, "tool1", "1.0", "api");
+    await cache.saveTool("k2", sampleTool, "tool2", "2.0", "api");
+    await cache.saveTool("k3", sampleTool, "tool3", "3.0", "local");
+    const stats = await cache.getCacheStats();
+    expect(stats.count).toBe(3);
+    expect(stats.bySource).toEqual({ api: 2, local: 1 });
+    expect(stats.totalBytes).toBeGreaterThan(0);
+    expect(stats.oldest).toBeDefined();
+    expect(stats.newest).toBeDefined();
+    expect(stats.oldest! <= stats.newest!).toBe(true);
+  });
+
+  it("getCacheStats omits totalBytes when storage lacks stat()", async () => {
+    const data = new Map<string, unknown>();
+    const statlessStorage = {
+      load: async (k: string) => data.get(k) ?? null,
+      save: async (k: string, v: unknown) => {
+        data.set(k, v);
+      },
+      delete: async (k: string) => {
+        data.delete(k);
+      },
+      list: async () => [...data.keys()].filter((k) => k !== "__index__"),
+    };
+    const statlessCache = new ToolCache({ storage: statlessStorage });
+    await statlessCache.saveTool("k1", sampleTool, "tool1", "1.0", "api");
+    const stats = await statlessCache.getCacheStats();
+    expect(stats.count).toBe(1);
+    expect(stats.bySource).toEqual({ api: 1 });
+    expect(stats.totalBytes).toBeUndefined();
+  });
+
+  it("FilesystemCacheStorage.stat returns sizeBytes and mtime", async () => {
+    const storage = new FilesystemCacheStorage(tmpDir);
+    await storage.save("statkey", { hello: "world" });
+    const s = await storage.stat("statkey");
+    expect(s).not.toBeNull();
+    expect(s!.sizeBytes).toBeGreaterThan(0);
+    expect(typeof s!.mtime).toBe("string");
+    expect(await storage.stat("missing")).toBeNull();
+  });
+
   it("writes valid JSON to disk", async () => {
     const key = "diskcheck";
     await cache.saveTool(key, sampleTool, "tool/id", "1.0", "api");


### PR DESCRIPTION
## Summary

Adds the small set of additions needed on `ToolCache` / `CacheStorage` to support a storage-agnostic Tool Cache Inspector (in `galaxy-workflows-vscode`) and richer endpoints in `tool-cache-proxy`. Mostly thin wrappers — no schema changes.

Implements [CACHE_ABSTRACTIONS_PLAN.md](https://github.com/jmchilton/galaxy-brain/blob/main/vault/projects/workflow_state/CACHE_ABSTRACTIONS_PLAN.md).

### `ToolCache`
- **`removeCached(key)`** — single-entry delete by cache key. Returns `true` if anything was removed (storage or index). Probes via `index.has` then `storage.list` membership; never decodes the payload.
- **`loadCachedRaw(key)`** — raw, undecoded payload. Lets the inspector render stale-schema or partially-written entries that `loadCached` would silently drop.
- **`getCacheStats()`** — returns `CacheStats { count, totalBytes?, bySource, oldest?, newest? }`. `totalBytes` is omitted when the storage backend doesn't implement `stat()`.
- Lazy-index backfill in `loadCached` now reads `version` off the decoded `ParsedTool` and tags the source as `"orphan"` so reconstructed entries can be flagged.

### `CacheStorage`
- **Optional `stat?(key)`** — returns `{ sizeBytes, mtime? } | null`. Implemented on:
  - `FilesystemCacheStorage`: `fs.stat()` (sizeBytes + mtime).
  - `IndexedDBCacheStorage`: `JSON.stringify(value).length` (or `Blob.size`); no mtime.
- Optional method, so existing implementations stay compatible.

### Tests
- `removeCached`: hit, miss, orphan-only (storage no index), index-only (index no storage).
- `loadCachedRaw`: undecoded payload that fails `ParsedTool` decode, missing key.
- Lazy-index backfill: asserts `source === "orphan"` and version comes off the decoded tool.
- `getCacheStats`: aggregates with stat-bearing backend; verifies `totalBytes` is `undefined` against an in-memory stat-less backend.
- `FilesystemCacheStorage.stat` (Node) and `IndexedDBCacheStorage.stat` (browser).

112/112 core tests pass; lint + format clean.

## Test plan

- [x] `pnpm -F @galaxy-tool-util/core test`
- [x] `pnpm -F @galaxy-tool-util/core lint` + `format`
- [ ] Browser-mode IndexedDB tests (`pnpm -F @galaxy-tool-util/core run test:browser`)
- [ ] Adopt in `tool-cache-proxy` and `galaxy-workflows-vscode` inspector (follow-up PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)