### PR TITLE
Tool Cache debug panel: gxwf-web routes + gxwf-ui tab

### DIFF
--- a/.changeset/tool-cache-debug-panel.md
+++ b/.changeset/tool-cache-debug-panel.md
@@ -1,0 +1,14 @@
+---
+"@galaxy-tool-util/core": minor
+"@galaxy-tool-util/gxwf-web": minor
+"@galaxy-tool-util/gxwf-client": minor
+"@galaxy-tool-util/gxwf-ui": minor
+---
+
+Tool Cache debugging panel.
+
+- `ToolCache.statCached(key)` — per-entry size/mtime (passthrough to `CacheStorage.stat`).
+- `ToolInfoService.refetch(toolId, version?, {force?})` — idempotent populate (short-circuits on cache hit) / forced re-fetch. Returns `{cacheKey, fetched, alreadyCached}`. Backs the new web routes and any future inspector surfaces.
+- `gxwf-web`: new `/api/tool-cache` routes — list (with `?decode=1` opt-in decode probe), stats, raw read, single + prefix delete, refetch, add. `AppState` now carries the full `ToolInfoService` (not just its cache) so refetch/add can drive the existing source-fallback logic.
+- `gxwf-client` regenerated to expose the new schemas.
+- `gxwf-ui`: new "Tool Cache" navbar tab with stats strip, filterable table (search / source dropdown / undecodable-only), per-row view-raw / refetch / open-toolshed / delete, and overflow menu (Add tool…, Clear by prefix…, Clear all). Decode-probe flags malformed payloads.

--- a/packages/core/src/cache/tool-cache.ts
+++ b/packages/core/src/cache/tool-cache.ts
@@ -113,6 +113,12 @@ export class ToolCache {
     return this.storage.load(key);
   }
 
+  /** Per-entry size/mtime if the storage backend supports it. */
+  async statCached(key: string): Promise<{ sizeBytes: number; mtime?: string } | null> {
+    if (typeof this.storage.stat !== "function") return null;
+    return this.storage.stat(key);
+  }
+
   /**
    * Remove a single cached entry by cache key. Returns true if anything was
    * removed (storage or index), false if neither held the key.
@@ -177,7 +183,8 @@ export class ToolCache {
     return stats;
   }
 
-  async clearCache(toolIdPrefix?: string): Promise<void> {
+  /** Clear cached entries. Returns the number of entries removed. */
+  async clearCache(toolIdPrefix?: string): Promise<number> {
     if (toolIdPrefix === undefined) {
       const keys = await this.storage.list();
       for (const key of keys) {
@@ -185,14 +192,15 @@ export class ToolCache {
       }
       await this.index.clear();
       this.memoryCache.clear();
-    } else {
-      const prefix = toolIdPrefix.replace(/\*$/, "");
-      const toRemove = (await this.index.listAll()).filter((e) => e.tool_id.startsWith(prefix));
-      for (const entry of toRemove) {
-        await this.storage.delete(entry.cache_key);
-        await this.index.remove(entry.cache_key);
-        this.memoryCache.delete(entry.cache_key);
-      }
+      return keys.length;
     }
+    const prefix = toolIdPrefix.replace(/\*$/, "");
+    const toRemove = (await this.index.listAll()).filter((e) => e.tool_id.startsWith(prefix));
+    for (const entry of toRemove) {
+      await this.storage.delete(entry.cache_key);
+      await this.index.remove(entry.cache_key);
+      this.memoryCache.delete(entry.cache_key);
+    }
+    return toRemove.length;
   }
 }

--- a/packages/core/src/tool-info.ts
+++ b/packages/core/src/tool-info.ts
@@ -128,6 +128,42 @@ export class ToolInfoService {
     }
   }
 
+  /**
+   * Populate the cache for a known tool id. Idempotent by default — when the
+   * entry already exists, returns `{alreadyCached: true, fetched: false}` and
+   * skips the remote fetch. Pass `{force: true}` to evict the existing entry
+   * first and re-fetch unconditionally.
+   *
+   * Used by inspector / debug surfaces (gxwf-web `/api/tool-cache/{add,refetch}`).
+   */
+  async refetch(
+    toolId: string,
+    toolVersion?: string | null,
+    opts?: { force?: boolean },
+  ): Promise<{ cacheKey: string; fetched: boolean; alreadyCached: boolean }> {
+    const coords = this.cache.resolveToolCoordinates(toolId, toolVersion ?? null);
+    let resolvedVersion = coords.version;
+    let alreadyCached = false;
+    if (resolvedVersion !== null) {
+      alreadyCached = await this.cache.hasCached(toolId, resolvedVersion);
+    }
+    if (alreadyCached && !opts?.force) {
+      const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, resolvedVersion!);
+      return { cacheKey: key, fetched: false, alreadyCached: true };
+    }
+    if (alreadyCached && opts?.force && resolvedVersion !== null) {
+      const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, resolvedVersion);
+      await this.cache.removeCached(key);
+    }
+    const tool = await this.getToolInfo(toolId, toolVersion ?? null);
+    if (tool === null) {
+      throw new Error(`Failed to fetch tool: ${toolId}`);
+    }
+    resolvedVersion = tool.version ?? resolvedVersion ?? "unknown";
+    const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, resolvedVersion);
+    return { cacheKey: key, fetched: true, alreadyCached };
+  }
+
   async addTool(
     toolId: string,
     toolVersion: string,

--- a/packages/core/test/cache.test.ts
+++ b/packages/core/test/cache.test.ts
@@ -217,7 +217,8 @@ describe("ToolCache", () => {
     await cache.saveTool("k1", sampleTool, "tool1", "1.0", "api");
     await cache.saveTool("k2", sampleTool, "tool2", "2.0", "api");
     expect(await cache.listCached()).toHaveLength(2);
-    await cache.clearCache();
+    const removed = await cache.clearCache();
+    expect(removed).toBe(2);
     expect(await cache.listCached()).toHaveLength(0);
   });
 
@@ -236,7 +237,8 @@ describe("ToolCache", () => {
       "1.0",
       "api",
     );
-    await cache.clearCache("toolshed.g2.bx.psu.edu/repos/devteam");
+    const removed = await cache.clearCache("toolshed.g2.bx.psu.edu/repos/devteam");
+    expect(removed).toBe(1);
     const remaining = await cache.listCached();
     expect(remaining).toHaveLength(1);
     expect(remaining[0].tool_id).toContain("multiqc");

--- a/packages/gxwf-ui/src/App.vue
+++ b/packages/gxwf-ui/src/App.vue
@@ -7,6 +7,7 @@
       <nav class="header-nav">
         <RouterLink to="/" class="nav-link">Workflows</RouterLink>
         <RouterLink to="/files" class="nav-link">Files</RouterLink>
+        <RouterLink to="/cache" class="nav-link">Tool Cache</RouterLink>
         <a
           href="https://iwc.galaxyproject.org/"
           target="_blank"

--- a/packages/gxwf-ui/src/components/ToolCacheRawDialog.vue
+++ b/packages/gxwf-ui/src/components/ToolCacheRawDialog.vue
@@ -1,0 +1,95 @@
+<template>
+  <Dialog
+    v-model:visible="visible"
+    :header="entry?.toolId ?? 'Cached payload'"
+    modal
+    :style="{ width: '70vw' }"
+    :breakpoints="{ '960px': '90vw' }"
+  >
+    <div v-if="loading" class="loading-state">Loading…</div>
+    <div v-else-if="error" class="error-state">{{ error }}</div>
+    <pre v-else class="raw-json">{{ pretty }}</pre>
+    <template #footer>
+      <Button label="Copy" icon="pi pi-copy" text :disabled="!pretty" @click="copy" />
+      <Button label="Close" icon="pi pi-times" @click="visible = false" />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import Button from "primevue/button";
+import Dialog from "primevue/dialog";
+import { useToast } from "primevue/usetoast";
+import type { components } from "@galaxy-tool-util/gxwf-client";
+
+type Entry = components["schemas"]["CachedToolEntry"];
+
+const props = defineProps<{
+  modelValue: boolean;
+  entry: Entry | null;
+  load: (cacheKey: string) => Promise<{ contents: unknown; decodable: boolean } | undefined>;
+}>();
+const emit = defineEmits<{ "update:modelValue": [v: boolean] }>();
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (v) => emit("update:modelValue", v),
+});
+
+const toast = useToast();
+const contents = ref<unknown>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const pretty = computed(() =>
+  contents.value !== null ? JSON.stringify(contents.value, null, 2) : "",
+);
+
+watch(
+  () => [props.modelValue, props.entry?.cacheKey],
+  async ([open, key]) => {
+    if (!open || !key) return;
+    loading.value = true;
+    error.value = null;
+    contents.value = null;
+    try {
+      const data = await props.load(key as string);
+      contents.value = data?.contents ?? null;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading.value = false;
+    }
+  },
+);
+
+async function copy() {
+  await navigator.clipboard.writeText(pretty.value);
+  toast.add({ severity: "success", summary: "Copied", life: 1500 });
+}
+</script>
+
+<style scoped>
+.raw-json {
+  max-height: 60vh;
+  overflow: auto;
+  margin: 0;
+  padding: var(--gx-sp-3);
+  background: var(--p-surface-100, #f3f4f6);
+  border-radius: 4px;
+  font-family: var(--gx-mono);
+  font-size: var(--gx-fs-xs);
+  white-space: pre;
+}
+
+.loading-state,
+.error-state {
+  padding: var(--gx-sp-4);
+  text-align: center;
+}
+
+.error-state {
+  color: var(--p-red-500, #ef4444);
+}
+</style>

--- a/packages/gxwf-ui/src/components/ToolCacheStats.vue
+++ b/packages/gxwf-ui/src/components/ToolCacheStats.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="cache-stats" data-description="tool cache stats">
+    <div class="stat-line">
+      <strong>{{ stats.count }}</strong> tools
+      <template v-if="stats.totalBytes !== undefined">
+        · <strong>{{ formatBytes(stats.totalBytes) }}</strong>
+      </template>
+      <template v-for="(n, source) in stats.bySource" :key="source">
+        · <strong>{{ n }}</strong> {{ source }}
+      </template>
+    </div>
+    <div v-if="stats.oldest || stats.newest" class="stat-line stat-meta">
+      <span v-if="stats.oldest">Oldest: {{ formatDate(stats.oldest) }}</span>
+      <span v-if="stats.newest">Newest: {{ formatDate(stats.newest) }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { components } from "@galaxy-tool-util/gxwf-client";
+
+defineProps<{ stats: components["schemas"]["CacheStats"] }>();
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+</script>
+
+<style scoped>
+.cache-stats {
+  padding: var(--gx-sp-3) var(--gx-sp-4);
+  background: var(--p-content-background, #fff);
+  border: 1px solid var(--p-content-border-color, #e5e7eb);
+  border-radius: 6px;
+  margin-bottom: var(--gx-sp-4);
+}
+
+.stat-line {
+  font-size: var(--gx-fs-sm);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  align-items: baseline;
+}
+
+.stat-meta {
+  margin-top: var(--gx-sp-2);
+  gap: var(--gx-sp-4);
+  color: var(--p-text-muted-color, #6b7280);
+  font-size: var(--gx-fs-xs);
+}
+</style>

--- a/packages/gxwf-ui/src/components/ToolCacheTable.vue
+++ b/packages/gxwf-ui/src/components/ToolCacheTable.vue
@@ -1,0 +1,239 @@
+<template>
+  <div class="cache-table">
+    <div class="list-toolbar">
+      <IconField class="search-field">
+        <InputIcon class="pi pi-search" />
+        <InputText v-model="filter" placeholder="Filter by tool id…" size="small" />
+      </IconField>
+      <Select
+        v-model="sourceFilter"
+        :options="sourceOptions"
+        placeholder="All sources"
+        showClear
+        size="small"
+        class="source-select"
+      />
+      <label class="undecodable-toggle">
+        <Checkbox v-model="undecodableOnly" :binary="true" />
+        <span>Undecodable only</span>
+      </label>
+      <span class="count">
+        {{ filtered.length }}{{ filtered.length !== entries.length ? ` of ${entries.length}` : "" }}
+        entries
+      </span>
+    </div>
+
+    <DataTable
+      :value="filtered"
+      :loading="loading"
+      dataKey="cacheKey"
+      :rowHover="true"
+      stripedRows
+      sortField="cachedAt"
+      :sortOrder="-1"
+      :paginator="filtered.length > 25"
+      :rows="25"
+      :rowsPerPageOptions="[25, 50, 100]"
+    >
+      <template #empty>
+        <div class="empty-state">
+          <i class="pi pi-database empty-icon" />
+          <p v-if="filter || sourceFilter || undecodableOnly">
+            No entries match the current filters.
+          </p>
+          <p v-else>The tool cache is empty.</p>
+        </div>
+      </template>
+
+      <Column field="toolId" header="Tool" sortable>
+        <template #body="{ data: row }">
+          <div class="tool-cell">
+            <i
+              v-if="!(row as Entry).decodable"
+              class="pi pi-exclamation-triangle warn-icon"
+              v-tooltip.right="'Cached payload does not decode as a ParsedTool'"
+            />
+            <span class="tool-id">{{ (row as Entry).toolId }}</span>
+          </div>
+        </template>
+      </Column>
+      <Column field="toolVersion" header="Version" sortable style="width: 10rem" />
+      <Column field="source" header="Source" sortable style="width: 7rem">
+        <template #body="{ data: row }">
+          <Tag :value="(row as Entry).source" severity="secondary" />
+        </template>
+      </Column>
+      <Column field="sizeBytes" header="Size" sortable style="width: 7rem">
+        <template #body="{ data: row }">
+          <span v-if="(row as Entry).sizeBytes !== undefined">
+            {{ formatBytes((row as Entry).sizeBytes!) }}
+          </span>
+          <span v-else class="muted">—</span>
+        </template>
+      </Column>
+      <Column field="cachedAt" header="Cached" sortable style="width: 11rem">
+        <template #body="{ data: row }">
+          <span :title="(row as Entry).cachedAt">{{
+            formatRelative((row as Entry).cachedAt)
+          }}</span>
+        </template>
+      </Column>
+      <Column header="" style="width: 11rem; text-align: right">
+        <template #body="{ data: row }">
+          <Button
+            icon="pi pi-eye"
+            text
+            size="small"
+            @click="emit('view', row as Entry)"
+            v-tooltip.left="'View raw JSON'"
+          />
+          <Button
+            icon="pi pi-refresh"
+            text
+            size="small"
+            :disabled="!(row as Entry).refetchable"
+            @click="emit('refetch', row as Entry)"
+            v-tooltip.left="
+              (row as Entry).refetchable
+                ? 'Re-fetch from source'
+                : 'Cannot re-fetch — tool id is unknown/orphan'
+            "
+          />
+          <a
+            v-if="(row as Entry).toolshedUrl"
+            :href="(row as Entry).toolshedUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button icon="pi pi-external-link" text size="small" v-tooltip.left="'Open ToolShed'" />
+          </a>
+          <Button
+            icon="pi pi-trash"
+            text
+            size="small"
+            severity="danger"
+            @click="emit('delete', row as Entry)"
+            v-tooltip.left="'Delete'"
+          />
+        </template>
+      </Column>
+    </DataTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import Button from "primevue/button";
+import Checkbox from "primevue/checkbox";
+import Column from "primevue/column";
+import DataTable from "primevue/datatable";
+import IconField from "primevue/iconfield";
+import InputIcon from "primevue/inputicon";
+import InputText from "primevue/inputtext";
+import Select from "primevue/select";
+import Tag from "primevue/tag";
+import type { components } from "@galaxy-tool-util/gxwf-client";
+
+type Entry = components["schemas"]["CachedToolEntry"];
+
+const props = defineProps<{ entries: Entry[]; loading?: boolean }>();
+const emit = defineEmits<{
+  view: [entry: Entry];
+  refetch: [entry: Entry];
+  delete: [entry: Entry];
+}>();
+
+const filter = ref("");
+const sourceFilter = ref<string | null>(null);
+const undecodableOnly = ref(false);
+
+const sourceOptions = computed(() =>
+  Array.from(new Set(props.entries.map((e) => e.source))).sort(),
+);
+
+const filtered = computed(() => {
+  const q = filter.value.toLowerCase();
+  return props.entries.filter((e) => {
+    if (q && !e.toolId.toLowerCase().includes(q)) return false;
+    if (sourceFilter.value && e.source !== sourceFilter.value) return false;
+    if (undecodableOnly.value && e.decodable) return false;
+    return true;
+  });
+});
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 48) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+</script>
+
+<style scoped>
+.list-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--gx-sp-3);
+  margin-bottom: var(--gx-sp-3);
+}
+
+.source-select {
+  min-width: 10rem;
+}
+
+.undecodable-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-size: var(--gx-fs-sm);
+  cursor: pointer;
+}
+
+.count {
+  margin-left: auto;
+  font-size: var(--gx-fs-sm);
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.tool-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
+.tool-id {
+  font-family: var(--gx-mono);
+}
+
+.warn-icon {
+  color: var(--p-orange-500, #f59e0b);
+}
+
+.muted {
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.empty-state {
+  text-align: center;
+  padding: var(--gx-sp-6) var(--gx-sp-4);
+  color: var(--p-text-muted-color, #6b7280);
+}
+
+.empty-icon {
+  font-size: 2rem;
+  display: block;
+  margin-bottom: var(--gx-sp-2);
+  opacity: 0.5;
+}
+</style>

--- a/packages/gxwf-ui/src/composables/useToolCache.ts
+++ b/packages/gxwf-ui/src/composables/useToolCache.ts
@@ -1,0 +1,109 @@
+import { ref } from "vue";
+import { useApi } from "./useApi";
+import type { components } from "@galaxy-tool-util/gxwf-client";
+
+type CachedToolEntry = components["schemas"]["CachedToolEntry"];
+type CacheStats = components["schemas"]["CacheStats"];
+
+// Module-level singleton: cache state is shared across components that call
+// useToolCache(), acting as a lightweight global store (mirrors useWorkflows).
+const entries = ref<CachedToolEntry[]>([]);
+const stats = ref<CacheStats>({ count: 0, bySource: {} });
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+/** Pull a server-side error message out of a router-style `{detail: "..."}` body, with fallbacks. */
+function detailOf(err: unknown, fallback: string): string {
+  if (err && typeof err === "object" && "detail" in err) {
+    const d = (err as { detail: unknown }).detail;
+    if (typeof d === "string" && d.length > 0) return d;
+  }
+  return fallback;
+}
+
+export function useToolCache() {
+  const client = useApi();
+
+  async function refresh(opts: { decode?: boolean } = {}) {
+    loading.value = true;
+    error.value = null;
+    try {
+      const { data, error: err } = await client.GET("/api/tool-cache", {
+        params: { query: opts.decode ? { decode: "1" } : {} },
+      });
+      if (err) {
+        error.value = detailOf(err, "Failed to load tool cache");
+      } else if (data) {
+        entries.value = data.entries;
+        stats.value = data.stats;
+      }
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function loadRaw(cacheKey: string) {
+    const { data, error: err } = await client.GET("/api/tool-cache/{cacheKey}", {
+      params: { path: { cacheKey } },
+    });
+    if (err) throw new Error(detailOf(err, "Failed to load raw entry"));
+    return data;
+  }
+
+  async function del(cacheKey: string) {
+    error.value = null;
+    const { error: err } = await client.DELETE("/api/tool-cache/{cacheKey}", {
+      params: { path: { cacheKey } },
+    });
+    if (err) {
+      const msg = detailOf(err, "Delete failed");
+      error.value = msg;
+      throw new Error(msg);
+    }
+    await refresh();
+  }
+
+  async function clear(prefix?: string) {
+    error.value = null;
+    const { data, error: err } = await client.DELETE("/api/tool-cache", {
+      params: { query: prefix ? { prefix } : {} },
+    });
+    if (err) {
+      const msg = detailOf(err, "Clear failed");
+      error.value = msg;
+      throw new Error(msg);
+    }
+    await refresh();
+    return data;
+  }
+
+  async function refetch(toolId: string, toolVersion?: string) {
+    error.value = null;
+    const { data, error: err } = await client.POST("/api/tool-cache/refetch", {
+      body: { toolId, ...(toolVersion ? { toolVersion } : {}) },
+    });
+    if (err) {
+      const msg = detailOf(err, "Refetch failed");
+      error.value = msg;
+      throw new Error(msg);
+    }
+    await refresh();
+    return data;
+  }
+
+  async function add(toolId: string, toolVersion?: string) {
+    error.value = null;
+    const { data, error: err } = await client.POST("/api/tool-cache/add", {
+      body: { toolId, ...(toolVersion ? { toolVersion } : {}) },
+    });
+    if (err) {
+      const msg = detailOf(err, "Add failed");
+      error.value = msg;
+      throw new Error(msg);
+    }
+    await refresh();
+    return data;
+  }
+
+  return { entries, stats, loading, error, refresh, loadRaw, del, clear, refetch, add };
+}

--- a/packages/gxwf-ui/src/main.ts
+++ b/packages/gxwf-ui/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 import PrimeVue from "primevue/config";
 import Tooltip from "primevue/tooltip";
 import ToastService from "primevue/toastservice";
+import ConfirmationService from "primevue/confirmationservice";
 import "primeicons/primeicons.css";
 import "./styles/galaxy.css";
 
@@ -13,5 +14,6 @@ const app = createApp(App);
 app.use(router);
 app.use(PrimeVue, { theme: { preset: GalaxyPreset, options: { darkModeSelector: ".dark" } } });
 app.use(ToastService);
+app.use(ConfirmationService);
 app.directive("tooltip", Tooltip);
 app.mount("#app");

--- a/packages/gxwf-ui/src/router/index.ts
+++ b/packages/gxwf-ui/src/router/index.ts
@@ -10,5 +10,6 @@ export default createRouter({
     { path: "/", component: DashboardView },
     { path: "/workflow/:path(.*)", component: () => import("../views/WorkflowView.vue") },
     { path: "/files/:path(.*)?", component: () => import("../views/FileView.vue") },
+    { path: "/cache", component: () => import("../views/ToolCacheView.vue") },
   ],
 });

--- a/packages/gxwf-ui/src/views/ToolCacheView.vue
+++ b/packages/gxwf-ui/src/views/ToolCacheView.vue
@@ -1,0 +1,293 @@
+<template>
+  <div>
+    <div class="view-header">
+      <div>
+        <h1>Tool Cache</h1>
+        <p class="subtitle">Inspect and manage the in-memory + on-disk parsed-tool cache.</p>
+      </div>
+      <div class="header-actions">
+        <label
+          class="decode-toggle"
+          v-tooltip.bottom="'Probe each entry for decode-ability (slower)'"
+        >
+          <Checkbox v-model="decodeProbe" :binary="true" @change="reload" />
+          <span>Decode probe</span>
+        </label>
+        <Button label="Refresh" icon="pi pi-refresh" text :loading="loading" @click="reload" />
+        <Button
+          icon="pi pi-ellipsis-v"
+          text
+          aria-label="Cache actions"
+          @click="(e) => menu?.toggle(e)"
+        />
+        <Menu ref="menu" :model="menuItems" :popup="true" />
+      </div>
+    </div>
+
+    <Message v-if="error" severity="error" :closable="false">{{ error }}</Message>
+
+    <ToolCacheStats :stats="stats" />
+
+    <ToolCacheTable
+      :entries="entries"
+      :loading="loading"
+      @view="viewEntry"
+      @refetch="refetchEntry"
+      @delete="confirmDelete"
+    />
+
+    <ToolCacheRawDialog v-model="rawOpen" :entry="rawEntry" :load="loadRaw" />
+
+    <Dialog v-model:visible="addOpen" header="Add tool to cache" modal :style="{ width: '24rem' }">
+      <div class="add-form">
+        <label>
+          <span>Tool ID</span>
+          <InputText
+            v-model="addToolId"
+            placeholder="toolshed.g2.../repos/owner/repo/tool/version"
+          />
+        </label>
+        <label>
+          <span>Version (optional)</span>
+          <InputText v-model="addToolVersion" />
+        </label>
+      </div>
+      <template #footer>
+        <Button label="Cancel" text @click="addOpen = false" />
+        <Button label="Add" icon="pi pi-plus" :loading="addPending" @click="doAdd" />
+      </template>
+    </Dialog>
+
+    <Dialog
+      v-model:visible="prefixOpen"
+      header="Clear by tool-id prefix"
+      modal
+      :style="{ width: '24rem' }"
+    >
+      <div class="add-form">
+        <label>
+          <span>Tool ID prefix</span>
+          <InputText v-model="prefixValue" placeholder="e.g. toolshed.g2.bx.psu.edu/repos/iuc/" />
+        </label>
+      </div>
+      <template #footer>
+        <Button label="Cancel" text @click="prefixOpen = false" />
+        <Button
+          label="Clear"
+          icon="pi pi-trash"
+          severity="danger"
+          :loading="clearPending"
+          @click="doClearPrefix"
+        />
+      </template>
+    </Dialog>
+
+    <ConfirmDialog />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import Button from "primevue/button";
+import Checkbox from "primevue/checkbox";
+import ConfirmDialog from "primevue/confirmdialog";
+import Dialog from "primevue/dialog";
+import InputText from "primevue/inputtext";
+import Menu from "primevue/menu";
+import Message from "primevue/message";
+import { useConfirm } from "primevue/useconfirm";
+import { useToast } from "primevue/usetoast";
+import ToolCacheStats from "../components/ToolCacheStats.vue";
+import ToolCacheTable from "../components/ToolCacheTable.vue";
+import ToolCacheRawDialog from "../components/ToolCacheRawDialog.vue";
+import { useToolCache } from "../composables/useToolCache";
+import type { components } from "@galaxy-tool-util/gxwf-client";
+
+type Entry = components["schemas"]["CachedToolEntry"];
+
+const { entries, stats, loading, error, refresh, loadRaw, del, clear, refetch, add } =
+  useToolCache();
+const toast = useToast();
+const confirm = useConfirm();
+
+const menu = ref<InstanceType<typeof Menu> | null>(null);
+const rawOpen = ref(false);
+const rawEntry = ref<Entry | null>(null);
+const decodeProbe = ref(false);
+
+function reload() {
+  void refresh({ decode: decodeProbe.value });
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+const addOpen = ref(false);
+const addToolId = ref("");
+const addToolVersion = ref("");
+const addPending = ref(false);
+
+const prefixOpen = ref(false);
+const prefixValue = ref("");
+const clearPending = ref(false);
+
+const menuItems = [
+  { label: "Add tool…", icon: "pi pi-plus", command: () => (addOpen.value = true) },
+  {
+    label: "Clear by prefix…",
+    icon: "pi pi-filter-slash",
+    command: () => (prefixOpen.value = true),
+  },
+  { separator: true },
+  {
+    label: "Clear all",
+    icon: "pi pi-trash",
+    command: () => {
+      confirm.require({
+        message: `Remove all ${stats.value.count} cached tools?`,
+        header: "Clear cache",
+        icon: "pi pi-exclamation-triangle",
+        acceptProps: { severity: "danger", label: "Clear all" },
+        accept: async () => {
+          try {
+            const data = await clear();
+            toast.add({
+              severity: "success",
+              summary: `Removed ${data?.removed ?? 0} entries`,
+              life: 2500,
+            });
+          } catch (e) {
+            toast.add({ severity: "error", summary: errMsg(e), life: 4000 });
+          }
+        },
+      });
+    },
+  },
+];
+
+function viewEntry(e: Entry) {
+  rawEntry.value = e;
+  rawOpen.value = true;
+}
+
+function confirmDelete(e: Entry) {
+  confirm.require({
+    message: `Delete cached entry for ${e.toolId} ${e.toolVersion}?`,
+    header: "Delete entry",
+    icon: "pi pi-exclamation-triangle",
+    acceptProps: { severity: "danger", label: "Delete" },
+    accept: async () => {
+      try {
+        await del(e.cacheKey);
+        toast.add({ severity: "success", summary: `Deleted ${e.toolId}`, life: 2000 });
+      } catch (err) {
+        toast.add({ severity: "error", summary: errMsg(err), life: 4000 });
+      }
+    },
+  });
+}
+
+async function refetchEntry(e: Entry) {
+  try {
+    await refetch(e.toolId, e.toolVersion);
+    toast.add({
+      severity: "success",
+      summary: `Re-fetched ${e.toolId} ${e.toolVersion}`,
+      life: 2500,
+    });
+  } catch (err) {
+    toast.add({ severity: "error", summary: `Failed: ${errMsg(err)}`, life: 4000 });
+  }
+}
+
+async function doAdd() {
+  if (!addToolId.value) return;
+  addPending.value = true;
+  try {
+    const data = await add(addToolId.value, addToolVersion.value || undefined);
+    toast.add({
+      severity: "success",
+      summary: data?.alreadyCached ? "Already cached" : `Added ${addToolId.value}`,
+      life: 2500,
+    });
+    addOpen.value = false;
+    addToolId.value = "";
+    addToolVersion.value = "";
+  } catch (err) {
+    toast.add({ severity: "error", summary: `Failed: ${errMsg(err)}`, life: 4000 });
+  } finally {
+    addPending.value = false;
+  }
+}
+
+async function doClearPrefix() {
+  if (!prefixValue.value) return;
+  clearPending.value = true;
+  try {
+    const data = await clear(prefixValue.value);
+    toast.add({
+      severity: "success",
+      summary: `Removed ${data?.removed ?? 0} entries`,
+      life: 2500,
+    });
+    prefixOpen.value = false;
+    prefixValue.value = "";
+  } catch (err) {
+    toast.add({ severity: "error", summary: errMsg(err), life: 4000 });
+  } finally {
+    clearPending.value = false;
+  }
+}
+
+onMounted(reload);
+</script>
+
+<style scoped>
+.view-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--gx-sp-4);
+  margin-bottom: var(--gx-sp-4);
+}
+
+.view-header h1 {
+  margin: 0 0 var(--gx-sp-1);
+  font-size: var(--gx-fs-xl);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--p-text-muted-color, #6b7280);
+  font-size: var(--gx-fs-sm);
+}
+
+.header-actions {
+  display: flex;
+  gap: var(--gx-sp-2);
+  align-items: center;
+}
+
+.decode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-size: var(--gx-fs-sm);
+  color: var(--p-text-muted-color, #6b7280);
+  cursor: pointer;
+}
+
+.add-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gx-sp-3);
+}
+
+.add-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3em;
+  font-size: var(--gx-fs-sm);
+}
+</style>

--- a/packages/gxwf-ui/test/composables/useToolCache.test.ts
+++ b/packages/gxwf-ui/test/composables/useToolCache.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const calls: { method: string; path: string; init?: unknown }[] = [];
+const responses = new Map<string, unknown>();
+const errors = new Map<string, unknown>();
+
+function reply(method: string, path: string, init: unknown) {
+  calls.push({ method, path, init });
+  const key = `${method} ${path}`;
+  if (errors.has(key)) return { data: undefined, error: errors.get(key) };
+  return { data: responses.get(key), error: undefined };
+}
+
+function fakeClient() {
+  return {
+    GET: vi.fn(async (path: string, init: unknown) => reply("GET", path, init)),
+    POST: vi.fn(async (path: string, init: unknown) => reply("POST", path, init)),
+    DELETE: vi.fn(async (path: string, init: unknown) => reply("DELETE", path, init)),
+  };
+}
+
+vi.mock("../../src/composables/useApi", () => ({ useApi: () => fakeClient() }));
+
+const { useToolCache } = await import("../../src/composables/useToolCache");
+
+beforeEach(() => {
+  calls.length = 0;
+  responses.clear();
+  errors.clear();
+});
+
+describe("useToolCache", () => {
+  it("refresh populates entries + stats", async () => {
+    responses.set("GET /api/tool-cache", {
+      entries: [
+        {
+          cacheKey: "k1",
+          toolId: "fastqc",
+          toolVersion: "0.74",
+          source: "api",
+          sourceUrl: "",
+          cachedAt: new Date().toISOString(),
+          decodable: true,
+        },
+      ],
+      stats: { count: 1, bySource: { api: 1 } },
+    });
+    const tc = useToolCache();
+    await tc.refresh();
+    expect(tc.entries.value).toHaveLength(1);
+    expect(tc.stats.value.count).toBe(1);
+    expect(calls[0].method).toBe("GET");
+    expect(calls[0].path).toBe("/api/tool-cache");
+    expect((calls[0].init as { params: { query: object } }).params.query).toEqual({});
+  });
+
+  it("refresh({decode: true}) sends ?decode=1", async () => {
+    responses.set("GET /api/tool-cache", { entries: [], stats: { count: 0, bySource: {} } });
+    const tc = useToolCache();
+    await tc.refresh({ decode: true });
+    expect((calls[0].init as { params: { query: object } }).params.query).toEqual({ decode: "1" });
+  });
+
+  it("delete refreshes after success", async () => {
+    responses.set("DELETE /api/tool-cache/{cacheKey}", { removed: true });
+    responses.set("GET /api/tool-cache", { entries: [], stats: { count: 0, bySource: {} } });
+    const tc = useToolCache();
+    await tc.del("k1");
+    expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual([
+      "DELETE /api/tool-cache/{cacheKey}",
+      "GET /api/tool-cache",
+    ]);
+  });
+
+  it("refetch passes toolId + toolVersion", async () => {
+    responses.set("POST /api/tool-cache/refetch", { cacheKey: "k1", fetched: true });
+    responses.set("GET /api/tool-cache", { entries: [], stats: { count: 0, bySource: {} } });
+    const tc = useToolCache();
+    await tc.refetch("fastqc", "0.74");
+    expect(calls[0].init).toEqual({ body: { toolId: "fastqc", toolVersion: "0.74" } });
+  });
+
+  it("add omits toolVersion when not given", async () => {
+    responses.set("POST /api/tool-cache/add", { cacheKey: "k1", alreadyCached: false });
+    responses.set("GET /api/tool-cache", { entries: [], stats: { count: 0, bySource: {} } });
+    const tc = useToolCache();
+    await tc.add("fastqc");
+    expect(calls[0].init).toEqual({ body: { toolId: "fastqc" } });
+  });
+
+  it("surfaces server detail on mutating-method failures", async () => {
+    errors.set("DELETE /api/tool-cache/{cacheKey}", { detail: "No cached entry: k1" });
+    const tc = useToolCache();
+    await expect(tc.del("k1")).rejects.toThrow("No cached entry: k1");
+    expect(tc.error.value).toBe("No cached entry: k1");
+  });
+});

--- a/packages/gxwf-web/openapi.json
+++ b/packages/gxwf-web/openapi.json
@@ -1016,6 +1016,170 @@
           }
         }
       }
+    },
+    "/api/tool-cache": {
+      "get": {
+        "tags": ["tool-cache"],
+        "summary": "List cached tools and aggregate stats",
+        "operationId": "list_tool_cache_api_tool_cache_get",
+        "parameters": [
+          {
+            "name": "decode",
+            "in": "query",
+            "required": false,
+            "description": "Set to '1' to probe each entry for ParsedTool decode-ability. Adds N file reads.",
+            "schema": { "type": "string", "enum": ["1"], "title": "Decode" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ToolCacheListResponse" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["tool-cache"],
+        "summary": "Clear all entries (or by tool-id prefix)",
+        "operationId": "clear_tool_cache_api_tool_cache_delete",
+        "parameters": [
+          {
+            "name": "prefix",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "title": "Prefix" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ToolCacheClearResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tool-cache/stats": {
+      "get": {
+        "tags": ["tool-cache"],
+        "summary": "Aggregate cache stats",
+        "operationId": "get_tool_cache_stats_api_tool_cache_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CacheStats" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tool-cache/refetch": {
+      "post": {
+        "tags": ["tool-cache"],
+        "summary": "Re-fetch a tool from its source (replacing the cached entry)",
+        "operationId": "refetch_tool_cache_api_tool_cache_refetch_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ToolCacheRefetchRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ToolCacheRefetchResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tool-cache/add": {
+      "post": {
+        "tags": ["tool-cache"],
+        "summary": "Populate the cache for a known tool id (diagnostic)",
+        "operationId": "add_tool_cache_api_tool_cache_add_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ToolCacheAddRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ToolCacheAddResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tool-cache/{cacheKey}": {
+      "get": {
+        "tags": ["tool-cache"],
+        "summary": "Get the raw cached payload",
+        "operationId": "read_tool_cache_api_tool_cache_key_get",
+        "parameters": [
+          {
+            "name": "cacheKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Cache Key" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ToolCacheRawResponse" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["tool-cache"],
+        "summary": "Delete a single cache entry",
+        "operationId": "delete_tool_cache_api_tool_cache_key_delete",
+        "parameters": [
+          {
+            "name": "cacheKey",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Cache Key" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ToolCacheDeleteResponse" }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2585,6 +2749,122 @@
         ],
         "title": "WorkflowIndex",
         "description": "Index of all workflows in the target directory."
+      },
+      "CachedToolEntry": {
+        "type": "object",
+        "title": "CachedToolEntry",
+        "required": [
+          "cacheKey",
+          "toolId",
+          "toolVersion",
+          "source",
+          "sourceUrl",
+          "cachedAt",
+          "decodable",
+          "refetchable"
+        ],
+        "properties": {
+          "cacheKey": { "type": "string", "title": "Cache Key" },
+          "toolId": { "type": "string", "title": "Tool Id" },
+          "toolVersion": { "type": "string", "title": "Tool Version" },
+          "source": { "type": "string", "title": "Source" },
+          "sourceUrl": { "type": "string", "title": "Source Url" },
+          "cachedAt": { "type": "string", "title": "Cached At" },
+          "sizeBytes": { "type": "integer", "title": "Size Bytes" },
+          "decodable": { "type": "boolean", "title": "Decodable" },
+          "toolshedUrl": { "type": "string", "title": "Toolshed Url" },
+          "refetchable": { "type": "boolean", "title": "Refetchable" }
+        }
+      },
+      "CacheStats": {
+        "type": "object",
+        "title": "CacheStats",
+        "required": ["count", "bySource"],
+        "properties": {
+          "count": { "type": "integer", "title": "Count" },
+          "totalBytes": { "type": "integer", "title": "Total Bytes" },
+          "bySource": {
+            "type": "object",
+            "additionalProperties": { "type": "integer" },
+            "title": "By Source"
+          },
+          "oldest": { "type": "string", "title": "Oldest" },
+          "newest": { "type": "string", "title": "Newest" }
+        }
+      },
+      "ToolCacheListResponse": {
+        "type": "object",
+        "title": "ToolCacheListResponse",
+        "required": ["entries", "stats"],
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CachedToolEntry" }
+          },
+          "stats": { "$ref": "#/components/schemas/CacheStats" }
+        }
+      },
+      "ToolCacheRawResponse": {
+        "type": "object",
+        "title": "ToolCacheRawResponse",
+        "required": ["contents", "decodable"],
+        "properties": {
+          "contents": { "title": "Contents" },
+          "decodable": { "type": "boolean", "title": "Decodable" }
+        }
+      },
+      "ToolCacheDeleteResponse": {
+        "type": "object",
+        "title": "ToolCacheDeleteResponse",
+        "required": ["removed"],
+        "properties": {
+          "removed": { "type": "boolean", "title": "Removed" }
+        }
+      },
+      "ToolCacheClearResponse": {
+        "type": "object",
+        "title": "ToolCacheClearResponse",
+        "required": ["removed"],
+        "properties": {
+          "removed": { "type": "integer", "title": "Removed" }
+        }
+      },
+      "ToolCacheRefetchRequest": {
+        "type": "object",
+        "title": "ToolCacheRefetchRequest",
+        "required": ["toolId"],
+        "properties": {
+          "toolId": { "type": "string", "title": "Tool Id" },
+          "toolVersion": { "type": "string", "title": "Tool Version" }
+        }
+      },
+      "ToolCacheRefetchResponse": {
+        "type": "object",
+        "title": "ToolCacheRefetchResponse",
+        "required": ["cacheKey", "fetched", "alreadyCached"],
+        "properties": {
+          "cacheKey": { "type": "string", "title": "Cache Key" },
+          "fetched": { "type": "boolean", "title": "Fetched" },
+          "alreadyCached": { "type": "boolean", "title": "Already Cached" }
+        }
+      },
+      "ToolCacheAddRequest": {
+        "type": "object",
+        "title": "ToolCacheAddRequest",
+        "required": ["toolId"],
+        "properties": {
+          "toolId": { "type": "string", "title": "Tool Id" },
+          "toolVersion": { "type": "string", "title": "Tool Version" }
+        }
+      },
+      "ToolCacheAddResponse": {
+        "type": "object",
+        "title": "ToolCacheAddResponse",
+        "required": ["cacheKey", "alreadyCached"],
+        "properties": {
+          "cacheKey": { "type": "string", "title": "Cache Key" },
+          "alreadyCached": { "type": "boolean", "title": "Already Cached" }
+        }
       }
     }
   }

--- a/packages/gxwf-web/src/app.ts
+++ b/packages/gxwf-web/src/app.ts
@@ -36,11 +36,11 @@ export function createApp(
     cacheDir: opts.cacheDir,
     sources: opts.sources,
   });
-  const cache = service.cache;
 
   const state: AppState = {
     directory,
-    cache,
+    cache: service.cache,
+    infoService: service,
     workflows: { directory, workflows: [] },
     cacheDir: opts.cacheDir,
     uiDir: opts.uiDir,
@@ -53,7 +53,7 @@ export function createApp(
   });
 
   const ready = (async () => {
-    await cache.index.load();
+    await service.cache.index.load();
     state.workflows = discoverWorkflows(directory);
   })();
 

--- a/packages/gxwf-web/src/generated/api-types.ts
+++ b/packages/gxwf-web/src/generated/api-types.ts
@@ -276,6 +276,93 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/tool-cache": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List cached tools and aggregate stats */
+    get: operations["list_tool_cache_api_tool_cache_get"];
+    put?: never;
+    post?: never;
+    /** Clear all entries (or by tool-id prefix) */
+    delete: operations["clear_tool_cache_api_tool_cache_delete"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/tool-cache/stats": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Aggregate cache stats */
+    get: operations["get_tool_cache_stats_api_tool_cache_stats_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/tool-cache/refetch": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Re-fetch a tool from its source (replacing the cached entry) */
+    post: operations["refetch_tool_cache_api_tool_cache_refetch_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/tool-cache/add": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Populate the cache for a known tool id (diagnostic) */
+    post: operations["add_tool_cache_api_tool_cache_add_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/tool-cache/{cacheKey}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the raw cached payload */
+    get: operations["read_tool_cache_api_tool_cache_key_get"];
+    put?: never;
+    post?: never;
+    /** Delete a single cache entry */
+    delete: operations["delete_tool_cache_api_tool_cache_key_delete"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -920,6 +1007,96 @@ export interface components {
       /** Workflows */
       workflows: components["schemas"]["WorkflowEntry"][];
     };
+    /** CachedToolEntry */
+    CachedToolEntry: {
+      /** Cache Key */
+      cacheKey: string;
+      /** Tool Id */
+      toolId: string;
+      /** Tool Version */
+      toolVersion: string;
+      /** Source */
+      source: string;
+      /** Source Url */
+      sourceUrl: string;
+      /** Cached At */
+      cachedAt: string;
+      /** Size Bytes */
+      sizeBytes?: number;
+      /** Decodable */
+      decodable: boolean;
+      /** Toolshed Url */
+      toolshedUrl?: string;
+      /** Refetchable */
+      refetchable: boolean;
+    };
+    /** CacheStats */
+    CacheStats: {
+      /** Count */
+      count: number;
+      /** Total Bytes */
+      totalBytes?: number;
+      /** By Source */
+      bySource: {
+        [key: string]: number;
+      };
+      /** Oldest */
+      oldest?: string;
+      /** Newest */
+      newest?: string;
+    };
+    /** ToolCacheListResponse */
+    ToolCacheListResponse: {
+      entries: components["schemas"]["CachedToolEntry"][];
+      stats: components["schemas"]["CacheStats"];
+    };
+    /** ToolCacheRawResponse */
+    ToolCacheRawResponse: {
+      /** Contents */
+      contents: unknown;
+      /** Decodable */
+      decodable: boolean;
+    };
+    /** ToolCacheDeleteResponse */
+    ToolCacheDeleteResponse: {
+      /** Removed */
+      removed: boolean;
+    };
+    /** ToolCacheClearResponse */
+    ToolCacheClearResponse: {
+      /** Removed */
+      removed: number;
+    };
+    /** ToolCacheRefetchRequest */
+    ToolCacheRefetchRequest: {
+      /** Tool Id */
+      toolId: string;
+      /** Tool Version */
+      toolVersion?: string;
+    };
+    /** ToolCacheRefetchResponse */
+    ToolCacheRefetchResponse: {
+      /** Cache Key */
+      cacheKey: string;
+      /** Fetched */
+      fetched: boolean;
+      /** Already Cached */
+      alreadyCached: boolean;
+    };
+    /** ToolCacheAddRequest */
+    ToolCacheAddRequest: {
+      /** Tool Id */
+      toolId: string;
+      /** Tool Version */
+      toolVersion?: string;
+    };
+    /** ToolCacheAddResponse */
+    ToolCacheAddResponse: {
+      /** Cache Key */
+      cacheKey: string;
+      /** Already Cached */
+      alreadyCached: boolean;
+    };
   };
   responses: never;
   parameters: never;
@@ -1534,6 +1711,163 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  list_tool_cache_api_tool_cache_get: {
+    parameters: {
+      query?: {
+        /** @description Set to '1' to probe each entry for ParsedTool decode-ability. Adds N file reads. */
+        decode?: "1";
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ToolCacheListResponse"];
+        };
+      };
+    };
+  };
+  clear_tool_cache_api_tool_cache_delete: {
+    parameters: {
+      query?: {
+        prefix?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ToolCacheClearResponse"];
+        };
+      };
+    };
+  };
+  get_tool_cache_stats_api_tool_cache_stats_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["CacheStats"];
+        };
+      };
+    };
+  };
+  refetch_tool_cache_api_tool_cache_refetch_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ToolCacheRefetchRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ToolCacheRefetchResponse"];
+        };
+      };
+    };
+  };
+  add_tool_cache_api_tool_cache_add_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ToolCacheAddRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ToolCacheAddResponse"];
+        };
+      };
+    };
+  };
+  read_tool_cache_api_tool_cache_key_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        cacheKey: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ToolCacheRawResponse"];
+        };
+      };
+    };
+  };
+  delete_tool_cache_api_tool_cache_key_delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        cacheKey: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ToolCacheDeleteResponse"];
         };
       };
     };

--- a/packages/gxwf-web/src/router.ts
+++ b/packages/gxwf-web/src/router.ts
@@ -10,7 +10,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import * as fs from "node:fs";
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
-import type { ToolCache } from "@galaxy-tool-util/core";
+import type { ToolCache, ToolInfoService } from "@galaxy-tool-util/core";
 import {
   GalaxyWorkflowSchema,
   NativeGalaxyWorkflowSchema,
@@ -46,12 +46,24 @@ import {
   type ExportConvertOptions,
   type RoundtripOptions,
 } from "./workflows.js";
+import {
+  addToolCacheEntry,
+  clearToolCache,
+  deleteToolCacheEntry,
+  getToolCacheRaw,
+  getToolCacheStats,
+  listToolCache,
+  refetchToolCacheEntry,
+  type AddRequest,
+  type RefetchRequest,
+} from "./tool-cache.js";
 
 // ── State ────────────────────────────────────────────────────────────
 
 export interface AppState {
   directory: string;
   cache: ToolCache;
+  infoService: ToolInfoService;
   workflows: WorkflowIndex;
   cacheDir?: string;
   /** Absolute path to a built gxwf-ui dist directory to serve as the frontend. */
@@ -232,7 +244,14 @@ type Route =
   | { handler: "listWorkflows" }
   | { handler: "refreshWorkflows" }
   | { handler: "workflowOp"; filePath: string; op: WorkflowOp; query: URLSearchParams }
-  | { handler: "structuralSchema"; query: URLSearchParams };
+  | { handler: "structuralSchema"; query: URLSearchParams }
+  | { handler: "toolCacheList"; query: URLSearchParams }
+  | { handler: "toolCacheStats" }
+  | { handler: "toolCacheRead"; cacheKey: string }
+  | { handler: "toolCacheDelete"; cacheKey: string }
+  | { handler: "toolCacheClear"; query: URLSearchParams }
+  | { handler: "toolCacheRefetch" }
+  | { handler: "toolCacheAdd" };
 
 function matchRoute(method: string, url: string): Route | null {
   const [rawPath, queryStr] = url.split("?");
@@ -241,6 +260,31 @@ function matchRoute(method: string, url: string): Route | null {
   // Structural schema: GET /api/schemas/structural
   if (rawPath === "/api/schemas/structural" && method === "GET") {
     return { handler: "structuralSchema", query };
+  }
+
+  // Tool cache routes
+  if (rawPath === "/api/tool-cache" || rawPath.startsWith("/api/tool-cache/")) {
+    if (rawPath === "/api/tool-cache") {
+      if (method === "GET") return { handler: "toolCacheList", query };
+      if (method === "DELETE") return { handler: "toolCacheClear", query };
+      return null;
+    }
+    if (rawPath === "/api/tool-cache/stats" && method === "GET") {
+      return { handler: "toolCacheStats" };
+    }
+    if (rawPath === "/api/tool-cache/refetch" && method === "POST") {
+      return { handler: "toolCacheRefetch" };
+    }
+    if (rawPath === "/api/tool-cache/add" && method === "POST") {
+      return { handler: "toolCacheAdd" };
+    }
+    const keyMatch = rawPath.match(/^\/api\/tool-cache\/([^/]+)$/);
+    if (keyMatch) {
+      const key = decodeURIComponent(keyMatch[1]);
+      if (method === "GET") return { handler: "toolCacheRead", cacheKey: key };
+      if (method === "DELETE") return { handler: "toolCacheDelete", cacheKey: key };
+    }
+    return null;
   }
 
   // Workflow list/refresh (must match before the per-workflow op pattern)
@@ -427,6 +471,45 @@ export function createRequestHandler(state: AppState) {
             state.workflows = discoverWorkflows(directory);
           }
           json(res, 200, result);
+          break;
+        }
+
+        case "toolCacheList": {
+          const decode = route.query.get("decode") === "1";
+          json(res, 200, await listToolCache(state, { decode }));
+          break;
+        }
+
+        case "toolCacheStats": {
+          json(res, 200, await getToolCacheStats(state));
+          break;
+        }
+
+        case "toolCacheRead": {
+          json(res, 200, await getToolCacheRaw(state, route.cacheKey));
+          break;
+        }
+
+        case "toolCacheDelete": {
+          json(res, 200, await deleteToolCacheEntry(state, route.cacheKey));
+          break;
+        }
+
+        case "toolCacheClear": {
+          const prefix = route.query.get("prefix") ?? undefined;
+          json(res, 200, await clearToolCache(state, prefix));
+          break;
+        }
+
+        case "toolCacheRefetch": {
+          const body = await readJsonBody<RefetchRequest>(req);
+          json(res, 200, await refetchToolCacheEntry(state, body));
+          break;
+        }
+
+        case "toolCacheAdd": {
+          const body = await readJsonBody<AddRequest>(req);
+          json(res, 200, await addToolCacheEntry(state, body));
           break;
         }
 

--- a/packages/gxwf-web/src/tool-cache.ts
+++ b/packages/gxwf-web/src/tool-cache.ts
@@ -1,0 +1,200 @@
+/**
+ * Tool cache inspection / management endpoints.
+ * Thin wrappers over `state.cache: ToolCache` and `state.infoService: ToolInfoService`.
+ */
+
+import * as S from "effect/Schema";
+import { ParsedTool } from "@galaxy-tool-util/schema";
+import { parseToolshedToolId, toolIdFromTrs } from "@galaxy-tool-util/core";
+import type { CacheStats } from "@galaxy-tool-util/core";
+import type { AppState } from "./router.js";
+import { HttpError } from "./contents.js";
+
+export interface CachedToolEntry {
+  cacheKey: string;
+  toolId: string;
+  toolVersion: string;
+  source: string;
+  sourceUrl: string;
+  cachedAt: string;
+  sizeBytes?: number;
+  decodable: boolean;
+  /** Deep link to the ToolShed repo page when the tool id is parseable. */
+  toolshedUrl?: string;
+  /** Whether this entry can drive a refetch — false for orphans / unknown ids. */
+  refetchable: boolean;
+}
+
+export interface ListResponse {
+  entries: CachedToolEntry[];
+  stats: CacheStats;
+}
+
+export interface RawResponse {
+  contents: unknown;
+  decodable: boolean;
+}
+
+export interface DeleteResponse {
+  removed: boolean;
+}
+
+export interface ClearResponse {
+  removed: number;
+}
+
+export interface RefetchRequest {
+  toolId: string;
+  toolVersion?: string;
+}
+
+export interface RefetchResponse {
+  cacheKey: string;
+  fetched: boolean;
+  alreadyCached: boolean;
+}
+
+export interface AddRequest {
+  toolId: string;
+  toolVersion?: string;
+}
+
+export interface AddResponse {
+  cacheKey: string;
+  alreadyCached: boolean;
+}
+
+const decodeParsedTool = S.decodeUnknownSync(ParsedTool);
+
+function tryDecode(contents: unknown): boolean {
+  try {
+    decodeParsedTool(contents);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface IndexEntry {
+  cache_key: string;
+  tool_id: string;
+  tool_version: string;
+  source: string;
+  source_url: string;
+  cached_at: string;
+}
+
+async function decorate(
+  state: AppState,
+  entry: IndexEntry,
+  decode: boolean,
+): Promise<CachedToolEntry> {
+  const parsed = parseToolshedToolId(entry.tool_id);
+  // An entry is refetchable when (a) we know which tool to ask for, and
+  // (b) it isn't an orphan reconstruction with placeholder metadata.
+  const refetchable =
+    entry.source !== "orphan" && entry.tool_id !== "unknown" && entry.tool_id !== "";
+  const out: CachedToolEntry = {
+    cacheKey: entry.cache_key,
+    toolId: entry.tool_id,
+    toolVersion: entry.tool_version,
+    source: entry.source,
+    sourceUrl: entry.source_url,
+    cachedAt: entry.cached_at,
+    // Default to true when not probing — UI shouldn't flag-as-broken what we
+    // didn't actually check. Callers wanting accuracy must pass `?decode=1`.
+    decodable: true,
+    refetchable,
+  };
+  if (parsed !== null) {
+    out.toolshedUrl = `https://${toolIdFromTrs(parsed.toolshedUrl, parsed.trsToolId)}`;
+  }
+
+  const stat = await state.cache.statCached(entry.cache_key);
+  if (stat !== null) out.sizeBytes = stat.sizeBytes;
+
+  if (decode) {
+    const raw = await state.cache.loadCachedRaw(entry.cache_key);
+    out.decodable = raw !== null && tryDecode(raw);
+  }
+
+  return out;
+}
+
+export interface ListOptions {
+  /** Probe each entry to flag undecodable payloads. Adds N file reads. */
+  decode?: boolean;
+}
+
+export async function listToolCache(
+  state: AppState,
+  opts: ListOptions = {},
+): Promise<ListResponse> {
+  // Single pass: derive aggregate stats from the same per-entry stats we need
+  // for the table. Avoids `getCacheStats()` re-walking the index.
+  const raw = (await state.cache.listCached()) as IndexEntry[];
+  const entries = await Promise.all(raw.map((e) => decorate(state, e, opts.decode === true)));
+
+  const bySource: Record<string, number> = {};
+  let oldest: string | undefined;
+  let newest: string | undefined;
+  let totalBytes = 0;
+  let anySize = false;
+  for (const e of entries) {
+    bySource[e.source] = (bySource[e.source] ?? 0) + 1;
+    if (oldest === undefined || e.cachedAt < oldest) oldest = e.cachedAt;
+    if (newest === undefined || e.cachedAt > newest) newest = e.cachedAt;
+    if (e.sizeBytes !== undefined) {
+      totalBytes += e.sizeBytes;
+      anySize = true;
+    }
+  }
+  const stats: CacheStats = { count: entries.length, bySource };
+  if (oldest !== undefined) stats.oldest = oldest;
+  if (newest !== undefined) stats.newest = newest;
+  if (anySize) stats.totalBytes = totalBytes;
+  return { entries, stats };
+}
+
+export async function getToolCacheStats(state: AppState): Promise<CacheStats> {
+  return state.cache.getCacheStats();
+}
+
+export async function getToolCacheRaw(state: AppState, key: string): Promise<RawResponse> {
+  const contents = await state.cache.loadCachedRaw(key);
+  if (contents === null) throw new HttpError(404, `No cached entry: ${key}`);
+  return { contents, decodable: tryDecode(contents) };
+}
+
+export async function deleteToolCacheEntry(state: AppState, key: string): Promise<DeleteResponse> {
+  const removed = await state.cache.removeCached(key);
+  if (!removed) throw new HttpError(404, `No cached entry: ${key}`);
+  return { removed };
+}
+
+export async function clearToolCache(state: AppState, prefix?: string): Promise<ClearResponse> {
+  const removed = await state.cache.clearCache(prefix);
+  return { removed };
+}
+
+export async function refetchToolCacheEntry(
+  state: AppState,
+  body: RefetchRequest,
+): Promise<RefetchResponse> {
+  if (!body.toolId) throw new HttpError(400, "toolId is required");
+  try {
+    return await state.infoService.refetch(body.toolId, body.toolVersion ?? null, { force: true });
+  } catch (e) {
+    throw new HttpError(502, e instanceof Error ? e.message : String(e));
+  }
+}
+
+export async function addToolCacheEntry(state: AppState, body: AddRequest): Promise<AddResponse> {
+  if (!body.toolId) throw new HttpError(400, "toolId is required");
+  try {
+    const r = await state.infoService.refetch(body.toolId, body.toolVersion ?? null);
+    return { cacheKey: r.cacheKey, alreadyCached: r.alreadyCached };
+  } catch (e) {
+    throw new HttpError(502, e instanceof Error ? e.message : String(e));
+  }
+}

--- a/packages/gxwf-web/test/tool-cache.test.ts
+++ b/packages/gxwf-web/test/tool-cache.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tool cache API tests.
+ * Real HTTP server against a temp dir; cache state seeded via
+ * `state.cache.saveTool` and the upstream FilesystemCacheStorage.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AddressInfo } from "node:net";
+import type { ParsedTool } from "@galaxy-tool-util/schema";
+import { cacheKey } from "@galaxy-tool-util/core";
+
+import { createApp } from "../src/app.js";
+import type { AppState } from "../src/app.js";
+
+interface TestServer {
+  baseUrl: string;
+  state: AppState;
+  close: () => Promise<void>;
+}
+
+const sampleToolJson = {
+  id: "fastqc",
+  version: "0.74+galaxy0",
+  name: "FastQC",
+  description: "Read Quality reports",
+  inputs: [],
+  outputs: [],
+  citations: [],
+  license: null,
+  profile: "16.01",
+  edam_operations: [],
+  edam_topics: [],
+  xrefs: [],
+};
+
+async function startTestServer(directory: string, cacheDir: string): Promise<TestServer> {
+  const { server, state, ready } = createApp(directory, { cacheDir });
+  await ready;
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve({
+        baseUrl: `http://127.0.0.1:${addr.port}`,
+        state,
+        close: () =>
+          new Promise<void>((res, rej) => server.close((err) => (err ? rej(err) : res()))),
+      });
+    });
+  });
+}
+
+let tmpDir: string;
+let cacheDir: string;
+let srv: TestServer;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gxwf-tc-"));
+  cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "gxwf-tc-cache-"));
+  srv = await startTestServer(tmpDir, cacheDir);
+});
+
+afterEach(async () => {
+  await srv.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+async function seedTool(
+  key: string,
+  toolId: string,
+  version: string,
+  source = "api",
+): Promise<void> {
+  await srv.state.cache.saveTool(
+    key,
+    sampleToolJson as unknown as ParsedTool,
+    toolId,
+    version,
+    source,
+    `https://example.test/api/tools/${toolId}/versions/${version}`,
+  );
+}
+
+describe("GET /api/tool-cache", () => {
+  it("returns empty list when nothing cached", async () => {
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.entries).toEqual([]);
+    expect(data.stats.count).toBe(0);
+    expect(data.stats.bySource).toEqual({});
+  });
+
+  it("returns entries + stats after seeding", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0", "api");
+    await seedTool("k2", "samtools_view", "1.15.1", "api");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache`);
+    const data = await res.json();
+    expect(data.entries).toHaveLength(2);
+    expect(data.stats.count).toBe(2);
+    expect(data.stats.bySource.api).toBe(2);
+    expect(data.stats.totalBytes).toBeGreaterThan(0);
+    const e = data.entries.find((x: { cacheKey: string }) => x.cacheKey === "k1");
+    expect(e.toolId).toBe("fastqc");
+    expect(e.toolVersion).toBe("0.74+galaxy0");
+    expect(e.decodable).toBe(true);
+    expect(e.refetchable).toBe(true);
+    expect(typeof e.sizeBytes).toBe("number");
+    expect(e.sizeBytes).toBeGreaterThan(0);
+  });
+
+  it("flags orphan / unknown entries as not refetchable + emits deep toolshedUrl", async () => {
+    await seedTool("k1", "unknown", "unknown", "orphan");
+    await seedTool("k2", "toolshed.g2.bx.psu.edu/repos/iuc/bwa/bwa_mem", "0.7.17.2", "api");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache`);
+    const data = await res.json();
+    const orphan = data.entries.find((x: { cacheKey: string }) => x.cacheKey === "k1");
+    const real = data.entries.find((x: { cacheKey: string }) => x.cacheKey === "k2");
+    expect(orphan.refetchable).toBe(false);
+    expect(orphan.toolshedUrl).toBeUndefined();
+    expect(real.refetchable).toBe(true);
+    // Deep link to the specific repo, not just the shed root.
+    expect(real.toolshedUrl).toBe("https://toolshed.g2.bx.psu.edu/repos/iuc/bwa/bwa_mem");
+  });
+
+  it("does not probe payloads without ?decode=1 (defaults decodable: true)", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0", "api");
+    fs.writeFileSync(path.join(cacheDir, "k1.json"), JSON.stringify({ not: "a parsed tool" }));
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache`);
+    const data = await res.json();
+    expect(data.entries[0].decodable).toBe(true);
+  });
+
+  it("flags malformed payloads as undecodable when ?decode=1 is set", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0", "api");
+    fs.writeFileSync(path.join(cacheDir, "k1.json"), JSON.stringify({ not: "a parsed tool" }));
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache?decode=1`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.entries[0].decodable).toBe(false);
+  });
+});
+
+describe("GET /api/tool-cache/stats", () => {
+  it("returns aggregate stats", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0", "api");
+    await seedTool("k2", "local_tool", "1.0", "local");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/stats`);
+    const data = await res.json();
+    expect(data.count).toBe(2);
+    expect(data.bySource).toEqual({ api: 1, local: 1 });
+    expect(data.totalBytes).toBeGreaterThan(0);
+    expect(data.oldest).toBeTruthy();
+    expect(data.newest).toBeTruthy();
+  });
+});
+
+describe("GET /api/tool-cache/{key}", () => {
+  it("returns raw payload + decodable=true for valid entries", async () => {
+    await seedTool("abc123", "fastqc", "0.74+galaxy0");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/abc123`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.decodable).toBe(true);
+    expect((data.contents as { id: string }).id).toBe("fastqc");
+  });
+
+  it("returns 404 for missing key", async () => {
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/no-such-key`);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 + decodable=false for corrupted payload", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0");
+    fs.writeFileSync(path.join(cacheDir, "k1.json"), JSON.stringify({ broken: true }));
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/k1`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.decodable).toBe(false);
+  });
+});
+
+describe("DELETE /api/tool-cache/{key}", () => {
+  it("removes the entry", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/k1`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    expect((await res.json()).removed).toBe(true);
+    expect(await srv.state.cache.listCached()).toEqual([]);
+  });
+
+  it("returns 404 when missing", async () => {
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/missing`, { method: "DELETE" });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/tool-cache (clear)", () => {
+  it("clears everything when no prefix given", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0");
+    await seedTool("k2", "samtools", "1.15.1");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache`, { method: "DELETE" });
+    const data = await res.json();
+    expect(data.removed).toBe(2);
+    expect(await srv.state.cache.listCached()).toEqual([]);
+  });
+
+  it("filters by tool-id prefix", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0");
+    await seedTool("k2", "fastqc_screen", "1.0");
+    await seedTool("k3", "samtools", "1.15.1");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache?prefix=fastqc`, { method: "DELETE" });
+    expect((await res.json()).removed).toBe(2);
+    const remaining = await srv.state.cache.listCached();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].tool_id).toBe("samtools");
+  });
+
+  it("strips trailing * from prefix", async () => {
+    await seedTool("k1", "fastqc", "0.74+galaxy0");
+    await seedTool("k2", "samtools", "1.15.1");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache?prefix=fastqc*`, { method: "DELETE" });
+    expect((await res.json()).removed).toBe(1);
+  });
+});
+
+describe("POST /api/tool-cache/refetch", () => {
+  it("400s without toolId", async () => {
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/refetch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("re-fetches via infoService (force=true even when cached)", async () => {
+    const coords = srv.state.cache.resolveToolCoordinates("fastqc", "0.74+galaxy0");
+    const realKey = await cacheKey(coords.toolshedUrl, coords.trsToolId, coords.version!);
+    await seedTool(realKey, "fastqc", "0.74+galaxy0", "api");
+    const decoded = sampleToolJson as unknown as ParsedTool;
+    const spy = vi.spyOn(srv.state.infoService, "getToolInfo").mockResolvedValue(decoded);
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/refetch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ toolId: "fastqc", toolVersion: "0.74+galaxy0" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.fetched).toBe(true);
+    expect(data.alreadyCached).toBe(true);
+    expect(typeof data.cacheKey).toBe("string");
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("502s when infoService can't fetch", async () => {
+    const spy = vi.spyOn(srv.state.infoService, "getToolInfo").mockResolvedValue(null);
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/refetch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ toolId: "no_such_tool" }),
+    });
+    expect(res.status).toBe(502);
+    spy.mockRestore();
+  });
+});
+
+describe("POST /api/tool-cache/add", () => {
+  it("populates a new entry", async () => {
+    const decoded = sampleToolJson as unknown as ParsedTool;
+    const spy = vi.spyOn(srv.state.infoService, "getToolInfo").mockResolvedValue(decoded);
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/add`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ toolId: "fastqc", toolVersion: "0.74+galaxy0" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.alreadyCached).toBe(false);
+    expect(typeof data.cacheKey).toBe("string");
+    spy.mockRestore();
+  });
+
+  it("short-circuits when entry already cached (no remote fetch)", async () => {
+    const coords = srv.state.cache.resolveToolCoordinates("fastqc", "0.74+galaxy0");
+    const realKey = await cacheKey(coords.toolshedUrl, coords.trsToolId, coords.version!);
+    await seedTool(realKey, "fastqc", "0.74+galaxy0", "api");
+    const spy = vi.spyOn(srv.state.infoService, "getToolInfo");
+    const res = await fetch(`${srv.baseUrl}/api/tool-cache/add`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ toolId: "fastqc", toolVersion: "0.74+galaxy0" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.alreadyCached).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a "Tool Cache" tab to `gxwf-ui` backed by new `/api/tool-cache` routes on `gxwf-web`. A debugging surface for the parsed-tool cache the server already maintains — list, inspect raw JSON, delete, re-fetch, populate-by-id.

**Backend (`@galaxy-tool-util/core`, `@galaxy-tool-util/gxwf-web`):**
- `ToolInfoService.refetch(toolId, version?, {force?})` — idempotent populate (short-circuits on cache hit) / forced re-fetch. Returns `{cacheKey, fetched, alreadyCached}`. Backs both add + refetch handlers.
- `ToolCache.statCached(key)` passthrough; `ToolCache.clearCache` now returns the removed count.
- New `/api/tool-cache` routes: list (with `?decode=1` opt-in decode probe), stats, raw read, single + prefix delete, refetch, add. `AppState` carries the full `ToolInfoService` so handlers stay one-line wrappers.
- `decorate()` emits server-computed `refetchable` + deep `toolshedUrl` (specific repo, not shed root).

**Frontend (`@galaxy-tool-util/gxwf-ui`):**
- New "Tool Cache" navlink + lazy route at `/cache`.
- Stats strip, filterable table (search / source dropdown / undecodable-only), per-row view-raw / refetch / open-toolshed / delete.
- Overflow menu: Add tool…, Clear by prefix…, Clear all (with confirm).
- Decode-probe toggle in the header (off by default — keeps list calls cheap).
- `useToolCache` composable surfaces server `{detail}` on errors via the reactive `error` ref.

**Listing performance:** single-pass over the index (N stats; +N reads only when `?decode=1` is set). No more `getCacheStats()` re-walking.

## Test plan
- [x] `pnpm --filter @galaxy-tool-util/gxwf-web test` — 107 pass (incl. 18 new tool-cache integration tests using a real HTTP server + real FS cache + mocked `infoService.getToolInfo`)
- [x] `pnpm --filter @galaxy-tool-util/gxwf-ui test` — 22 pass (incl. 6 new `useToolCache` tests covering refresh / decode flag / mutating-method wiring / server-error surfacing)
- [x] `pnpm --filter @galaxy-tool-util/core test` — 118 pass (`clearCache` return-count assertions added)
- [x] Lint + format clean across touched packages
- [ ] Manual smoke against a populated IWC workflows directory: navigate `/cache`, confirm list / decode-probe / refetch / delete / add flows
- [ ] Verify VS Code extension flow still works (shared cache, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)