### PR TITLE
Type ParsedTool outputs

### DIFF
--- a/.changeset/typed-parsed-tool-outputs.md
+++ b/.changeset/typed-parsed-tool-outputs.md
@@ -1,0 +1,5 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+Type ParsedTool outputs against current Galaxy output models.

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -61,7 +61,26 @@ export {
   isConditionalParam,
 } from "./schema/type-guards.js";
 
-export { ParsedTool, HelpContent, XrefDict, Citation } from "./schema/parsed-tool.js";
+export {
+  ParsedTool,
+  HelpContent,
+  XrefDict,
+  Citation,
+  DiscoverVia,
+  SortKey,
+  SortComp,
+  DatasetCollectionDescription,
+  ToolProvidedMetadataDatasetCollection,
+  FilePatternDatasetCollectionDescription,
+  ToolOutput,
+  ToolOutputDataset,
+  ToolOutputCollectionStructure,
+  ToolOutputCollection,
+  ToolOutputText,
+  ToolOutputInteger,
+  ToolOutputFloat,
+  ToolOutputBoolean,
+} from "./schema/parsed-tool.js";
 
 export {
   type GalaxyWorkflow,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -80,6 +80,7 @@ export {
   ToolOutputInteger,
   ToolOutputFloat,
   ToolOutputBoolean,
+  parsedToolSchema,
 } from "./schema/parsed-tool.js";
 
 export {

--- a/packages/schema/src/schema/parsed-tool.ts
+++ b/packages/schema/src/schema/parsed-tool.ts
@@ -1,4 +1,5 @@
 import * as S from "effect/Schema";
+import * as JSONSchema from "effect/JSONSchema";
 
 import type { ToolParameterModel } from "./bundle-types.js";
 
@@ -129,7 +130,7 @@ const NullableDescription = S.transform(S.NullOr(S.String), S.NullOr(S.String), 
 const ToolParameterModelSchema: S.Schema<ToolParameterModel> = S.declare(
   (input: unknown): input is ToolParameterModel =>
     typeof input === "object" && input !== null && !Array.isArray(input),
-);
+).annotations({ jsonSchema: { type: "object" } });
 
 /**
  * Effect Schema for parsed Galaxy tool metadata as returned by the ToolShed TRS API
@@ -150,6 +151,8 @@ export const ParsedTool = S.Struct({
   xrefs: S.Array(XrefDict),
   help: S.optional(S.Union(HelpContent, S.Null)),
 });
+
+export const parsedToolSchema = JSONSchema.make(ParsedTool, { target: "jsonSchema2020-12" });
 
 export type DiscoverVia = S.Schema.Type<typeof DiscoverVia>;
 export type SortKey = S.Schema.Type<typeof SortKey>;

--- a/packages/schema/src/schema/parsed-tool.ts
+++ b/packages/schema/src/schema/parsed-tool.ts
@@ -20,6 +20,99 @@ export const Citation = S.Struct({
   content: S.String,
 });
 
+export const DiscoverVia = S.Literal("pattern", "tool_provided_metadata");
+export const SortKey = S.Literal("filename", "name", "designation", "dbkey");
+export const SortComp = S.Literal("lexical", "numeric");
+
+const DatasetCollectionDescriptionBase = S.Struct({
+  discover_via: DiscoverVia,
+  format: S.NullOr(S.String),
+  visible: S.Boolean,
+  assign_primary_output: S.Boolean,
+  directory: S.NullOr(S.String),
+  recurse: S.Boolean,
+  match_relative_path: S.Boolean,
+});
+
+export const ToolProvidedMetadataDatasetCollection = S.Struct({
+  ...DatasetCollectionDescriptionBase.fields,
+  discover_via: S.Literal("tool_provided_metadata"),
+});
+
+export const FilePatternDatasetCollectionDescription = S.Struct({
+  ...DatasetCollectionDescriptionBase.fields,
+  discover_via: S.Literal("pattern"),
+  sort_key: SortKey,
+  sort_comp: SortComp,
+  sort_reverse: S.Boolean,
+  pattern: S.String,
+});
+
+export const DatasetCollectionDescription = S.Union(
+  FilePatternDatasetCollectionDescription,
+  ToolProvidedMetadataDatasetCollection,
+);
+
+const ToolOutputBase = S.Struct({
+  name: S.String,
+  label: S.NullOr(S.String),
+  hidden: S.Boolean,
+});
+
+export const ToolOutputDataset = S.Struct({
+  ...ToolOutputBase.fields,
+  type: S.Literal("data"),
+  format: S.String,
+  format_source: S.NullOr(S.String),
+  metadata_source: S.NullOr(S.String),
+  discover_datasets: S.NullOr(S.Array(DatasetCollectionDescription)),
+  from_work_dir: S.NullOr(S.String),
+  precreate_directory: S.Boolean,
+});
+
+export const ToolOutputCollectionStructure = S.Struct({
+  collection_type: S.NullOr(S.String),
+  collection_type_source: S.NullOr(S.String),
+  collection_type_from_rules: S.NullOr(S.String),
+  structured_like: S.NullOr(S.String),
+  discover_datasets: S.NullOr(S.Array(DatasetCollectionDescription)),
+});
+
+export const ToolOutputCollection = S.Struct({
+  ...ToolOutputBase.fields,
+  type: S.Literal("collection"),
+  structure: ToolOutputCollectionStructure,
+});
+
+export const ToolOutputText = S.Struct({
+  ...ToolOutputBase.fields,
+  type: S.Literal("text"),
+});
+
+export const ToolOutputInteger = S.Struct({
+  ...ToolOutputBase.fields,
+  type: S.Literal("integer"),
+});
+
+export const ToolOutputFloat = S.Struct({
+  ...ToolOutputBase.fields,
+  type: S.Literal("float"),
+});
+
+export const ToolOutputBoolean = S.Struct({
+  ...ToolOutputBase.fields,
+  type: S.Literal("boolean"),
+});
+
+export const ToolOutput = S.Union(
+  ToolOutputDataset,
+  ToolOutputCollection,
+  ToolOutputText,
+  ToolOutputInteger,
+  ToolOutputFloat,
+  ToolOutputBoolean,
+);
+
 /** Normalize empty string to null for description field. */
 const NullableDescription = S.transform(S.NullOr(S.String), S.NullOr(S.String), {
   decode: (val) => (val === "" ? null : val),
@@ -48,7 +141,7 @@ export const ParsedTool = S.Struct({
   name: S.String,
   description: NullableDescription,
   inputs: S.Array(ToolParameterModelSchema),
-  outputs: S.Array(S.Unknown),
+  outputs: S.Array(ToolOutput),
   citations: S.Array(Citation),
   license: S.NullOr(S.String),
   profile: S.NullOr(S.String),
@@ -58,4 +151,22 @@ export const ParsedTool = S.Struct({
   help: S.optional(S.Union(HelpContent, S.Null)),
 });
 
+export type DiscoverVia = S.Schema.Type<typeof DiscoverVia>;
+export type SortKey = S.Schema.Type<typeof SortKey>;
+export type SortComp = S.Schema.Type<typeof SortComp>;
+export type ToolProvidedMetadataDatasetCollection = S.Schema.Type<
+  typeof ToolProvidedMetadataDatasetCollection
+>;
+export type FilePatternDatasetCollectionDescription = S.Schema.Type<
+  typeof FilePatternDatasetCollectionDescription
+>;
+export type DatasetCollectionDescription = S.Schema.Type<typeof DatasetCollectionDescription>;
+export type ToolOutputDataset = S.Schema.Type<typeof ToolOutputDataset>;
+export type ToolOutputCollectionStructure = S.Schema.Type<typeof ToolOutputCollectionStructure>;
+export type ToolOutputCollection = S.Schema.Type<typeof ToolOutputCollection>;
+export type ToolOutputText = S.Schema.Type<typeof ToolOutputText>;
+export type ToolOutputInteger = S.Schema.Type<typeof ToolOutputInteger>;
+export type ToolOutputFloat = S.Schema.Type<typeof ToolOutputFloat>;
+export type ToolOutputBoolean = S.Schema.Type<typeof ToolOutputBoolean>;
+export type ToolOutput = S.Schema.Type<typeof ToolOutput>;
 export type ParsedTool = S.Schema.Type<typeof ParsedTool>;

--- a/packages/schema/test/parsed-tool.test.ts
+++ b/packages/schema/test/parsed-tool.test.ts
@@ -22,6 +22,89 @@ describe("ParsedTool", () => {
     expect(result.edam_topics).toEqual([]);
   });
 
+  it("decodes FastQC data outputs with typed fields", () => {
+    const result = S.decodeUnknownSync(ParsedTool)(fastqcFixture);
+    const output = result.outputs[0];
+    if (!output || output.type !== "data") {
+      throw new Error("expected first FastQC output to be a data output");
+    }
+
+    expect(output.name).toBe("html_file");
+    expect(output.format).toBe("html");
+    expect(output.from_work_dir).toBe("output.html");
+    expect(output.discover_datasets).toHaveLength(1);
+
+    const discovery = output.discover_datasets?.[0];
+    if (!discovery || discovery.discover_via !== "pattern") {
+      throw new Error("expected FastQC output discovery by pattern");
+    }
+    expect(discovery.pattern).toContain("primary_DATASET_ID");
+    expect(discovery.sort_key).toBe("filename");
+  });
+
+  it("decodes collection and simple scalar outputs", () => {
+    const tool = {
+      id: "output_shapes",
+      version: null,
+      name: "Output Shapes",
+      description: null,
+      inputs: [],
+      outputs: [
+        {
+          name: "summary",
+          label: null,
+          hidden: false,
+          type: "text",
+        },
+        {
+          name: "count",
+          label: null,
+          hidden: false,
+          type: "integer",
+        },
+        {
+          name: "scores",
+          label: "scores",
+          hidden: false,
+          type: "collection",
+          structure: {
+            collection_type: "list",
+            collection_type_source: null,
+            collection_type_from_rules: null,
+            structured_like: null,
+            discover_datasets: [
+              {
+                discover_via: "tool_provided_metadata",
+                format: "txt",
+                visible: true,
+                assign_primary_output: false,
+                directory: null,
+                recurse: false,
+                match_relative_path: false,
+              },
+            ],
+          },
+        },
+      ],
+      citations: [],
+      license: null,
+      profile: null,
+      edam_operations: [],
+      edam_topics: [],
+      xrefs: [],
+    };
+
+    const result = S.decodeUnknownSync(ParsedTool)(tool);
+    expect(result.outputs.map((output) => output.type)).toEqual(["text", "integer", "collection"]);
+
+    const collection = result.outputs[2];
+    if (!collection || collection.type !== "collection") {
+      throw new Error("expected third output to be a collection output");
+    }
+    expect(collection.structure.collection_type).toBe("list");
+    expect(collection.structure.discover_datasets?.[0]?.discover_via).toBe("tool_provided_metadata");
+  });
+
   it("rejects missing required fields", () => {
     expect(() => S.decodeUnknownSync(ParsedTool)({})).toThrow();
     expect(() => S.decodeUnknownSync(ParsedTool)({ id: "x" })).toThrow();

--- a/packages/schema/test/parsed-tool.test.ts
+++ b/packages/schema/test/parsed-tool.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import * as S from "effect/Schema";
-import { ParsedTool } from "../src/schema/parsed-tool.js";
+import Ajv2020Import from "ajv/dist/2020.js";
+import { ParsedTool, parsedToolSchema } from "../src/schema/parsed-tool.js";
 import fastqcFixture from "../../core/test/fixtures/fastqc-parsed-tool.json" with { type: "json" };
+
+const Ajv2020 = Ajv2020Import as unknown as typeof Ajv2020Import.default;
 
 describe("ParsedTool", () => {
   it("decodes a real ToolShed fastqc response", () => {
@@ -103,6 +106,26 @@ describe("ParsedTool", () => {
     }
     expect(collection.structure.collection_type).toBe("list");
     expect(collection.structure.discover_datasets?.[0]?.discover_via).toBe("tool_provided_metadata");
+  });
+
+  it("exports a JSON Schema that validates FastQC parsed tool fixtures", () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    const validate = ajv.compile(parsedToolSchema as object);
+
+    expect(validate(fastqcFixture), JSON.stringify(validate.errors)).toBe(true);
+    expect(JSON.stringify(parsedToolSchema)).toContain("from_work_dir");
+    expect(JSON.stringify(parsedToolSchema)).toContain("tool_provided_metadata");
+  });
+
+  it("exports a JSON Schema with typed output requirements", () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    const validate = ajv.compile(parsedToolSchema as object);
+    const invalid = {
+      ...fastqcFixture,
+      outputs: [{ name: "bad", label: null, hidden: false, type: "data" }],
+    };
+
+    expect(validate(invalid)).toBe(false);
   });
 
   it("rejects missing required fields", () => {

--- a/packages/schema/test/parsed-tool.test.ts
+++ b/packages/schema/test/parsed-tool.test.ts
@@ -105,7 +105,9 @@ describe("ParsedTool", () => {
       throw new Error("expected third output to be a collection output");
     }
     expect(collection.structure.collection_type).toBe("list");
-    expect(collection.structure.discover_datasets?.[0]?.discover_via).toBe("tool_provided_metadata");
+    expect(collection.structure.discover_datasets?.[0]?.discover_via).toBe(
+      "tool_provided_metadata",
+    );
   });
 
   it("exports a JSON Schema that validates FastQC parsed tool fixtures", () => {


### PR DESCRIPTION
## Summary
- Add Effect Schema models for current Galaxy ParsedTool output variants and dataset discovery descriptions.
- Replace ParsedTool outputs from unknown[] with the typed ToolOutput union and export the schemas.
- Export `parsedToolSchema` as a JSON Schema object for Foundry `package_export` reuse.
- Add focused ParsedTool tests for FastQC output fields, collection/scalar outputs, and JSON Schema fixture validation.

## Tests
- pnpm --filter @galaxy-tool-util/schema test
- pnpm --filter @galaxy-tool-util/core test
- pnpm --filter @galaxy-tool-util/schema lint

Closes #88