### PR TITLE
Add galaxy-tool-cache summarize command

### DIFF
--- a/.changeset/summarize-tool.md
+++ b/.changeset/summarize-tool.md
@@ -1,0 +1,5 @@
+---
+"@galaxy-tool-util/cli": minor
+---
+
+Add `galaxy-tool-cache summarize <tool_id>` — emits a JSON manifest for a cached tool (source metadata, ParsedTool, and `workflow_step` / `workflow_step_linked` input JSON Schemas).

--- a/packages/cli/spec/galaxy-tool-cache.json
+++ b/packages/cli/spec/galaxy-tool-cache.json
@@ -112,6 +112,31 @@
       ]
     },
     {
+      "name": "summarize",
+      "description": "Emit a deterministic summary manifest for a cached Galaxy tool",
+      "handler": "summarize",
+      "args": [
+        {
+          "raw": "<tool_id>",
+          "description": "Tool ID"
+        }
+      ],
+      "options": [
+        {
+          "flags": "--version <ver>",
+          "description": "Tool version"
+        },
+        {
+          "flags": "--output <file>",
+          "description": "Output file (default: stdout)"
+        },
+        {
+          "flags": "--cache-dir <dir>",
+          "description": "Cache directory"
+        }
+      ]
+    },
+    {
       "name": "populate-workflow",
       "description": "Scan a workflow and cache all referenced tools",
       "handler": "populateWorkflow",

--- a/packages/cli/src/commands/summarize.ts
+++ b/packages/cli/src/commands/summarize.ts
@@ -1,0 +1,126 @@
+import { join } from "node:path";
+import { writeFile } from "node:fs/promises";
+import { getCacheDir, makeNodeToolCache } from "@galaxy-tool-util/core/node";
+import {
+  createFieldModel,
+  type ParsedTool,
+  type StateRepresentation,
+  type ToolParameterBundleModel,
+} from "@galaxy-tool-util/schema";
+import * as JSONSchema from "effect/JSONSchema";
+import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+
+export interface SummarizeOptions {
+  version?: string;
+  output?: string;
+  cacheDir?: string;
+}
+
+export interface GalaxyToolSummaryManifest {
+  schema_version: 1;
+  tool_id: string;
+  tool_version: string | null;
+  cache_key: string;
+  source: {
+    kind: "toolshed" | "galaxy" | "local" | "orphan" | "unknown";
+    label: string;
+    url: string;
+    cached_at: string | null;
+  };
+  artifacts: {
+    parsed_tool_path: string;
+    raw_tool_source_path: string | null;
+  };
+  parsed_tool: ParsedTool;
+  input_schemas: {
+    workflow_step: unknown | null;
+    workflow_step_linked: unknown | null;
+  };
+  warnings: string[];
+}
+
+function sourceKind(label: string | undefined): GalaxyToolSummaryManifest["source"]["kind"] {
+  if (label === "api") return "toolshed";
+  if (label === "galaxy" || label === "local" || label === "orphan") return label;
+  return "unknown";
+}
+
+function inputSchemaFor(
+  tool: ParsedTool,
+  rep: StateRepresentation,
+  warnings: string[],
+): unknown | null {
+  const bundle: ToolParameterBundleModel = {
+    parameters: tool.inputs as ToolParameterBundleModel["parameters"],
+  };
+  const effectSchema = createFieldModel(bundle, rep);
+  if (effectSchema === undefined) {
+    warnings.push(`${rep} input schema could not be generated for this tool`);
+    return null;
+  }
+  try {
+    return JSONSchema.make(effectSchema);
+  } catch (err) {
+    warnings.push(
+      `${rep} input schema generation failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}
+
+export async function buildToolSummaryManifest(
+  toolId: string,
+  opts: SummarizeOptions,
+): Promise<GalaxyToolSummaryManifest | null> {
+  const cacheDir = getCacheDir(opts.cacheDir);
+  const cache = makeNodeToolCache({ cacheDir });
+  await cache.index.load();
+  const result = await loadCachedTool(cache, toolId, opts.version);
+  if (isResolveError(result)) {
+    if (result.kind === "no_version") {
+      console.error(`No version specified for tool: ${toolId}`);
+    } else {
+      console.error(`Tool not found in cache: ${toolId}. Run 'galaxy-tool-cache add' first.`);
+    }
+    process.exitCode = 1;
+    return null;
+  }
+
+  const indexEntry = (await cache.index.listAll()).find((entry) => entry.cache_key === result.key);
+  const warnings: string[] = [];
+  const manifest: GalaxyToolSummaryManifest = {
+    schema_version: 1,
+    tool_id: result.tool.id,
+    tool_version: result.tool.version,
+    cache_key: result.key,
+    source: {
+      kind: sourceKind(indexEntry?.source),
+      label: indexEntry?.source ?? "unknown",
+      url: indexEntry?.source_url ?? "",
+      cached_at: indexEntry?.cached_at ?? null,
+    },
+    artifacts: {
+      parsed_tool_path: join(cacheDir, `${result.key}.json`),
+      raw_tool_source_path: null,
+    },
+    parsed_tool: result.tool,
+    input_schemas: {
+      workflow_step: inputSchemaFor(result.tool, "workflow_step", warnings),
+      workflow_step_linked: inputSchemaFor(result.tool, "workflow_step_linked", warnings),
+    },
+    warnings,
+  };
+  return manifest;
+}
+
+export async function runSummarize(toolId: string, opts: SummarizeOptions): Promise<void> {
+  const manifest = await buildToolSummaryManifest(toolId, opts);
+  if (manifest === null) return;
+  const output = `${JSON.stringify(manifest, null, 2)}\n`;
+  if (opts.output) {
+    await writeFile(opts.output, output);
+    console.log(`Summary written to ${opts.output}`);
+  } else {
+    process.stdout.write(output);
+  }
+}

--- a/packages/cli/src/programs/galaxy-tool-cache.ts
+++ b/packages/cli/src/programs/galaxy-tool-cache.ts
@@ -9,6 +9,7 @@ import { runInfo } from "../commands/info.js";
 import { runClear } from "../commands/clear.js";
 import { runPopulateWorkflow } from "../commands/populate-workflow.js";
 import { runSchema } from "../commands/schema.js";
+import { runSummarize } from "../commands/summarize.js";
 import { runStructuralSchema } from "../commands/structural-schema.js";
 import { buildProgramFromSpec, type HandlerRegistry } from "../spec/build-program.js";
 import { galaxyToolCacheSpec } from "../meta/specs.js";
@@ -19,6 +20,7 @@ const handlers: HandlerRegistry = {
   info: runInfo,
   clear: runClear,
   schema: runSchema,
+  summarize: runSummarize,
   populateWorkflow: runPopulateWorkflow,
   structuralSchema: runStructuralSchema,
 };

--- a/packages/cli/test/summarize.test.ts
+++ b/packages/cli/test/summarize.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as S from "effect/Schema";
+import { cacheKey } from "@galaxy-tool-util/core";
+import { makeNodeToolCache } from "@galaxy-tool-util/core/node";
+import { ParsedTool } from "@galaxy-tool-util/schema";
+import fastqcFixture from "../../core/test/fixtures/fastqc-parsed-tool.json" with { type: "json" };
+import { buildToolSummaryManifest, runSummarize } from "../src/commands/summarize.js";
+import { createCliTestContext, type CliTestContext } from "./helpers/cli-test-context.js";
+
+const FASTQC_TOOL_ID = "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc";
+const FASTQC_VERSION = "0.74+galaxy0";
+
+describe("galaxy-tool-cache summarize", () => {
+  let ctx: CliTestContext;
+
+  beforeEach(async () => {
+    ctx = await createCliTestContext("summarize-test");
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function seedFastqc(): Promise<string> {
+    const cache = makeNodeToolCache({ cacheDir: ctx.tmpDir });
+    const key = await cacheKey(
+      "https://toolshed.g2.bx.psu.edu",
+      "devteam~fastqc~fastqc",
+      FASTQC_VERSION,
+    );
+    const parsed = S.decodeUnknownSync(ParsedTool)(fastqcFixture);
+    await cache.saveTool(
+      key,
+      parsed,
+      FASTQC_TOOL_ID,
+      FASTQC_VERSION,
+      "api",
+      `https://toolshed.g2.bx.psu.edu/api/tools/devteam~fastqc~fastqc/versions/${FASTQC_VERSION}`,
+    );
+    return key;
+  }
+
+  it("builds a deterministic manifest for a cached ParsedTool", async () => {
+    const key = await seedFastqc();
+
+    const manifest = await buildToolSummaryManifest(FASTQC_TOOL_ID, {
+      version: FASTQC_VERSION,
+      cacheDir: ctx.tmpDir,
+    });
+
+    expect(manifest).not.toBeNull();
+    expect(manifest?.schema_version).toBe(1);
+    expect(manifest?.source.kind).toBe("toolshed");
+    expect(manifest?.parsed_tool.name).toBe("FastQC");
+    expect(manifest?.input_schemas.workflow_step).not.toBeNull();
+    expect(manifest?.input_schemas.workflow_step_linked).not.toBeNull();
+    expect(manifest?.artifacts.parsed_tool_path).toContain(`${key}.json`);
+  });
+
+  it("writes JSON to stdout by default", async () => {
+    await seedFastqc();
+
+    await runSummarize(FASTQC_TOOL_ID, { version: FASTQC_VERSION, cacheDir: ctx.tmpDir });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = ctx.stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    const manifest = JSON.parse(output);
+    expect(manifest.tool_id).toBe("fastqc");
+  });
+
+  it("writes JSON to --output", async () => {
+    await seedFastqc();
+    const outPath = join(ctx.tmpDir, "summary.json");
+
+    await runSummarize(FASTQC_TOOL_ID, {
+      version: FASTQC_VERSION,
+      cacheDir: ctx.tmpDir,
+      output: outPath,
+    });
+
+    const manifest = JSON.parse(await readFile(outPath, "utf-8"));
+    expect(manifest.parsed_tool.id).toBe("fastqc");
+  });
+});


### PR DESCRIPTION
## Summary
- New `galaxy-tool-cache summarize <tool_id> [--version <ver>] [--output <file>] [--cache-dir <dir>]` subcommand emitting a deterministic JSON manifest for a cached tool.
- Manifest carries `schema_version`, source metadata (toolshed/galaxy/local/orphan/unknown + url + cached_at), `parsed_tool`, and per-representation input JSON Schemas (`workflow_step`, `workflow_step_linked`), plus a `warnings` channel for schema-gen failures.
- Driven by downstream foundry need: jmchilton/foundry#44.

## Test plan
- [x] `make check`
- [x] `make test` (cli: 3 new tests, full suite green)
- [ ] Manual smoke: `galaxy-tool-cache add <tool> && galaxy-tool-cache summarize <tool> --version <v>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)