### PR TITLE
Move structural-schema from galaxy-tool-cache to gxwf

### DIFF
--- a/.changeset/move-structural-schema-to-gxwf.md
+++ b/.changeset/move-structural-schema-to-gxwf.md
@@ -1,0 +1,5 @@
+---
+"@galaxy-tool-util/cli": minor
+---
+
+Move `structural-schema` subcommand from `galaxy-tool-cache` to `gxwf`. The command exports workflow JSON Schemas, so it belongs alongside other `gxwf` workflow operations. No back-compat alias.

--- a/docs/guide/workflow-operations.md
+++ b/docs/guide/workflow-operations.md
@@ -381,8 +381,8 @@ gxwf tool-revisions devteam/fastqc/fastqc --tool-version 0.74+galaxy0 --latest -
 Export the structural workflow JSON Schema for use with external validators:
 
 ```bash
-galaxy-tool-cache structural-schema --output galaxy-workflow-schema.json
-galaxy-tool-cache structural-schema --format native --output native-schema.json
+gxwf structural-schema --output galaxy-workflow-schema.json
+gxwf structural-schema --format native --output native-schema.json
 ```
 
 ## Programmatic Usage
@@ -460,7 +460,7 @@ Mapping between Python CLI commands and their TypeScript equivalents:
 | `gxwf-roundtrip-validate` | `gxwf roundtrip` | Done |
 | `gxwf-roundtrip-validate-tree` | `gxwf roundtrip-tree` | Done |
 | `galaxy-tool-cache populate-workflow` | `galaxy-tool-cache populate-workflow` | Done |
-| `galaxy-tool-cache structural-schema` | `galaxy-tool-cache structural-schema` | Done |
+| `galaxy-tool-cache structural-schema` | `gxwf structural-schema` | Done |
 | `galaxy-tool-cache add-local` | — | Out of scope (no local XML parsing) |
 | `gxwf-viz` | — | Out of scope |
 | `gxwf-abstract-export` | — | Out of scope |

--- a/docs/packages/cli.md
+++ b/docs/packages/cli.md
@@ -105,23 +105,6 @@ galaxy-tool-cache populate-workflow my-workflow.gxwf.yml --galaxy-url https://us
 | `--cache-dir <dir>` | Cache directory |
 | `--galaxy-url <url>` | Galaxy instance URL for fallback fetching |
 
-### `structural-schema`
-
-Export the structural [JSON Schema](https://json-schema.org) for Galaxy workflow files. Enables external tooling to validate workflow structure without the TS runtime.
-
-```bash
-# Format2 schema (default)
-galaxy-tool-cache structural-schema
-
-# Native format schema, write to file
-galaxy-tool-cache structural-schema --format native --output native-schema.json
-```
-
-| Option | Description |
-|---|---|
-| `--format <fmt>` | Workflow format: `format2` (default) or `native` |
-| `--output <file>` | Write to file instead of stdout |
-
 ## gxwf
 
 Unified CLI for Galaxy workflow operations. Replaces the standalone `galaxy-workflow-validate` binary.
@@ -618,3 +601,20 @@ The flag is `--tool-version` rather than `--version` because commander's program
 
 Caveat: tool version strings are not monotonic — two changesets can legally publish the
 same `version` with different content. When pinning, prefer the newest matching revision.
+
+### `structural-schema`
+
+Export the structural [JSON Schema](https://json-schema.org) for Galaxy workflow files. Enables external tooling to validate workflow structure without the TS runtime.
+
+```bash
+# Format2 schema (default)
+gxwf structural-schema
+
+# Native format schema, write to file
+gxwf structural-schema --format native --output native-schema.json
+```
+
+| Option | Description |
+|---|---|
+| `--format <fmt>` | Workflow format: `format2` (default) or `native` |
+| `--output <file>` | Write to file instead of stdout |

--- a/docs/skills/gxwf-cli/SKILL.md
+++ b/docs/skills/gxwf-cli/SKILL.md
@@ -29,6 +29,7 @@ Validate Galaxy workflow files (structure + optional tool state)
 | `--tool-schema-dir <dir>` | Directory of pre-exported per-tool JSON Schemas (for offline json-schema mode) |
 | `--json` | Output structured JSON report |
 | `--report-html [file]` | Write HTML report to file (or stdout if omitted) |
+| `--connections` | Validate connection-type compatibility (collection algebra, map-over) |
 | `--strict` | Shorthand for --strict-structure --strict-encoding --strict-state |
 | `--strict-structure` | Reject unknown keys at envelope/step level |
 | `--strict-encoding` | Reject JSON-string tool_state and format2 field misuse |
@@ -141,6 +142,24 @@ Render a Galaxy workflow as a Mermaid flowchart diagram
 | Option | Description |
 |---|---|
 | `--comments` | Render frame comments as Mermaid subgraphs |
+| `--annotate-connections` | Encode map-over depth and reductions on edges (runs the connection validator) |
+| `--cache-dir <dir>` | Tool cache directory (used by --annotate-connections) |
+
+### `cytoscapejs <file> [output]`
+
+Render a Galaxy workflow as Cytoscape.js elements (JSON or standalone HTML)
+
+**Arguments:**
+
+- `<file>` — Workflow file (.ga, .gxwf.yml)
+- `[output]` — Output path (.json or .html); stdout JSON if omitted
+
+| Option | Description |
+|---|---|
+| `--html` | Force HTML output regardless of file extension |
+| `--json` | Force JSON output regardless of file extension |
+| `--annotate-connections` | Encode map-over depth and reductions on edges (runs the connection validator) |
+| `--cache-dir <dir>` | Tool cache directory (used by --annotate-connections) |
 
 ### `validate-tree <dir>`
 
@@ -327,6 +346,15 @@ Search the Galaxy Tool Shed for repositories. Ranking is popularity-boosted; sup
 | `--category <name>` | Restrict to a category (server-side `category:` keyword) |
 | `--json` | Emit machine-readable JSON envelope |
 
+### `structural-schema`
+
+Export the structural JSON Schema for Galaxy workflows
+
+| Option | Description |
+|---|---|
+| `--format <fmt>` | Workflow format: format2 (default) or native (default: `format2`) |
+| `--output <file>` | Output file (default: stdout) |
+
 ## `galaxy-tool-cache`
 
 Cache and inspect Galaxy tool metadata
@@ -394,6 +422,20 @@ Export JSON Schema for a cached tool's parameters
 | `--output <file>` | Output file (default: stdout) |
 | `--cache-dir <dir>` | Cache directory |
 
+### `summarize <tool_id>`
+
+Emit a deterministic summary manifest for a cached Galaxy tool
+
+**Arguments:**
+
+- `<tool_id>` — Tool ID
+
+| Option | Description |
+|---|---|
+| `--version <ver>` | Tool version |
+| `--output <file>` | Output file (default: stdout) |
+| `--cache-dir <dir>` | Cache directory |
+
 ### `populate-workflow <file>`
 
 Scan a workflow and cache all referenced tools
@@ -406,12 +448,3 @@ Scan a workflow and cache all referenced tools
 |---|---|
 | `--cache-dir <dir>` | Cache directory |
 | `--galaxy-url <url>` | Galaxy instance URL for fallback |
-
-### `structural-schema`
-
-Export the structural JSON Schema for Galaxy workflows
-
-| Option | Description |
-|---|---|
-| `--format <fmt>` | Workflow format: format2 (default) or native (default: `format2`) |
-| `--output <file>` | Output file (default: stdout) |

--- a/packages/cli/spec/galaxy-tool-cache.json
+++ b/packages/cli/spec/galaxy-tool-cache.json
@@ -156,22 +156,6 @@
           "description": "Galaxy instance URL for fallback"
         }
       ]
-    },
-    {
-      "name": "structural-schema",
-      "description": "Export the structural JSON Schema for Galaxy workflows",
-      "handler": "structuralSchema",
-      "options": [
-        {
-          "flags": "--format <fmt>",
-          "description": "Workflow format: format2 (default) or native",
-          "default": "format2"
-        },
-        {
-          "flags": "--output <file>",
-          "description": "Output file (default: stdout)"
-        }
-      ]
     }
   ]
 }

--- a/packages/cli/spec/gxwf.json
+++ b/packages/cli/spec/gxwf.json
@@ -688,6 +688,22 @@
           "description": "Emit machine-readable JSON envelope"
         }
       ]
+    },
+    {
+      "name": "structural-schema",
+      "description": "Export the structural JSON Schema for Galaxy workflows",
+      "handler": "structuralSchema",
+      "options": [
+        {
+          "flags": "--format <fmt>",
+          "description": "Workflow format: format2 (default) or native",
+          "default": "format2"
+        },
+        {
+          "flags": "--output <file>",
+          "description": "Output file (default: stdout)"
+        }
+      ]
     }
   ]
 }

--- a/packages/cli/src/commands/structural-schema.ts
+++ b/packages/cli/src/commands/structural-schema.ts
@@ -1,5 +1,5 @@
 /**
- * `galaxy-tool-cache structural-schema` — export the structural JSON Schema
+ * `gxwf structural-schema` — export the structural JSON Schema
  * for Galaxy workflow validation (gxformat2 or native).
  */
 import { GalaxyWorkflowSchema, NativeGalaxyWorkflowSchema } from "@galaxy-tool-util/schema";

--- a/packages/cli/src/programs/galaxy-tool-cache.ts
+++ b/packages/cli/src/programs/galaxy-tool-cache.ts
@@ -10,7 +10,6 @@ import { runClear } from "../commands/clear.js";
 import { runPopulateWorkflow } from "../commands/populate-workflow.js";
 import { runSchema } from "../commands/schema.js";
 import { runSummarize } from "../commands/summarize.js";
-import { runStructuralSchema } from "../commands/structural-schema.js";
 import { buildProgramFromSpec, type HandlerRegistry } from "../spec/build-program.js";
 import { galaxyToolCacheSpec } from "../meta/specs.js";
 
@@ -22,7 +21,6 @@ const handlers: HandlerRegistry = {
   schema: runSchema,
   summarize: runSummarize,
   populateWorkflow: runPopulateWorkflow,
-  structuralSchema: runStructuralSchema,
 };
 
 export function buildGalaxyToolCacheProgram(): Command {

--- a/packages/cli/src/programs/gxwf.ts
+++ b/packages/cli/src/programs/gxwf.ts
@@ -23,6 +23,7 @@ import { runToolSearch } from "../commands/tool-search.js";
 import { runToolVersions } from "../commands/tool-versions.js";
 import { runToolRevisions } from "../commands/tool-revisions.js";
 import { runRepoSearch } from "../commands/repo-search.js";
+import { runStructuralSchema } from "../commands/structural-schema.js";
 import { buildProgramFromSpec, type HandlerRegistry } from "../spec/build-program.js";
 import { gxwfSpec } from "../meta/specs.js";
 
@@ -73,6 +74,7 @@ const handlers: HandlerRegistry = {
   toolVersions: runToolVersions,
   toolRevisions: runToolRevisions,
   repoSearch: runRepoSearch,
+  structuralSchema: runStructuralSchema,
 };
 
 export function buildGxwfProgram(): Command {

--- a/packages/cli/test/structural-schema.test.ts
+++ b/packages/cli/test/structural-schema.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { runStructuralSchema } from "../src/commands/structural-schema.js";
 import { createCliTestContext, type CliTestContext } from "./helpers/cli-test-context.js";
 
-describe("galaxy-tool-cache structural-schema", () => {
+describe("gxwf structural-schema", () => {
   let ctx: CliTestContext;
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary
- `structural-schema` exports workflow JSON Schemas (`GalaxyWorkflowSchema` / `NativeGalaxyWorkflowSchema`) — it belongs alongside other `gxwf` workflow operations, not under the tool metadata cache CLI.
- Relocates the subcommand, handler, docs, and SKILL.md entry. No back-compat alias.

## Test plan
- [x] `pnpm --filter @galaxy-tool-util/cli test` (262 pass)
- [x] `make check` (lint + format + typecheck)
- [x] `make gen-skill` regenerates SKILL.md cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)