### PR TITLE
fix(schema): draft-checks fix-ups from review (stacked on #100)

### DIFF
--- a/.changeset/draft-checks-fixups.md
+++ b/.changeset/draft-checks-fixups.md
@@ -1,0 +1,13 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+Fix-ups to `draft-checks.ts` from an independent review pass:
+
+- `detectDraft` now reads TODO sentinels from list-form step `in:` entries (`in: [{ id: "TODO_x", source: "..." }]`), matching the long-supported list-form coverage in `validateDraft`. Previously dict-form was the only path that hit the sentinel walker.
+- `validateDraft` now emits the "top-level `_plan_*`" warning at every draft root (outer document + every nested draft subworkflow root), not just the outermost. Inner-draft `_plan_*` was previously silent.
+- `TODO_LIKE` heuristic anchored to `/^TODO([_-]|$)/` (was `/^TODO/`), so identifiers like `TODONE`, `TODOLIST` no longer false-positive as "malformed sentinels."
+- Added a documentation comment clarifying the intentional asymmetry between `detectDraft` (step-focused survey; ignores top-level `_plan_*`) and `validateDraft` (rules-focused walker; warns).
+- Added documentation comment on inner-draft outputs path convention (path = outer step's path, mirrors how subworkflow steps reach their inner workflow).
+
+7 new tests covering each fix-up + an input-ordering idempotence test for `nextDraftStep`.

--- a/packages/schema/src/workflow/draft-checks.ts
+++ b/packages/schema/src/workflow/draft-checks.ts
@@ -16,7 +16,10 @@ import { GalaxyWorkflowDraftSchema } from "./raw/gxformat2-draft.effect.js";
 export const TODO_SENTINEL_PATTERN = /^TODO(_[a-z0-9_]+)?$/;
 // Heuristic for TODO-shaped strings — flags malformed sentinels (TODO-foo,
 // TODOfoo, TODO_, TODO_Foo with uppercase) that the canonical pattern misses.
-const TODO_LIKE = /^TODO/;
+// Anchored: only TODO followed by `_`, `-`, or end-of-string counts; this
+// avoids false positives on unrelated identifiers that happen to start with
+// TODO (e.g. TODOLIST, TODONE).
+const TODO_LIKE = /^TODO([_-]|$)/;
 
 export const PLAN_FIELDS = ["_plan_state", "_plan_context", "_plan_in", "_plan_out"] as const;
 export type PlanField = (typeof PLAN_FIELDS)[number];
@@ -68,6 +71,12 @@ export interface DraftSurvey {
  *
  * Step paths are `[outerLabel, ..., innerStepLabel]`. Subworkflows recurse
  * only when the inner `run:` block also carries `class: GalaxyWorkflowDraft`.
+ *
+ * Note: this survey is step-focused — it intentionally does NOT report
+ * top-level `_plan_*` fields on a draft workflow root. Those are flagged
+ * by `validateDraft` (a rules-focused walker); `detectDraft` exists to
+ * drive `nextDraftStep` / `extractConcreteSubset`, which only act on
+ * per-step state.
  */
 export function detectDraft(workflow: unknown): DraftSurvey {
   const todos: TodoHit[] = [];
@@ -99,6 +108,10 @@ function walkDraftSteps(
   }
 
   // Workflow-level outputs: outputSource may contain a TODO port reference.
+  // For inner draft subworkflows (recursive call), `prefix` is the path to
+  // reach this workflow (i.e. the outer step's path); inner outputs collect
+  // at that prefix. For the outermost call `prefix` is [], so outer outputs
+  // collect at path [].
   for (const [label, output] of iterateOutputs(workflow.outputs)) {
     const ref = readOutputSource(output);
     if (ref == null) continue;
@@ -124,11 +137,11 @@ function collectStepTodos(step: Record<string, unknown>, path: StepPath, todos: 
       sentinel: step.tool_version,
     });
   }
-  if (isRecord(step.in)) {
-    for (const key of Object.keys(step.in)) {
-      if (isTodoSentinel(key)) {
-        todos.push({ path, location: { kind: "in_key", key }, sentinel: key });
-      }
+  // Use the shared iterator so dict-form (`in: { TODO_x: ... }`) and list-form
+  // (`in: [{ id: TODO_x, source: ... }]`) draft inputs are covered uniformly.
+  for (const [key] of iterateStepInputEntries(step.in)) {
+    if (isTodoSentinel(key)) {
+      todos.push({ path, location: { kind: "in_key", key }, sentinel: key });
     }
   }
   for (const id of iterateStepOutIds(step.out)) {
@@ -300,16 +313,6 @@ export function validateDraft(workflow: unknown): DraftValidationResult {
     }
   }
 
-  for (const field of PLAN_FIELDS) {
-    const value = (workflow as Record<string, unknown>)[field];
-    if (typeof value === "string" && value.length > 0) {
-      warnings.push({
-        path: [],
-        message: `top-level \`${field}\` is not part of the draft contract; planning fields belong on individual steps`,
-      });
-    }
-  }
-
   const ok =
     structureErrors.length === 0 && topologyErrors.length === 0 && semanticErrors.length === 0;
 
@@ -323,6 +326,19 @@ function walkDraftValidation(
   semanticErrors: DraftValidationDiagnostic[],
   warnings: DraftValidationDiagnostic[],
 ): void {
+  // Plan fields belong on individual steps, never at a draft root — applies
+  // to the outer document AND any nested draft subworkflow root reached via
+  // recursion below.
+  for (const field of PLAN_FIELDS) {
+    const value = workflow[field];
+    if (typeof value === "string" && value.length > 0) {
+      warnings.push({
+        path: prefix,
+        message: `top-level \`${field}\` is not part of the draft contract; planning fields belong on individual steps`,
+      });
+    }
+  }
+
   // Workflow inputs: labels and types must be concrete.
   const inputLabels = new Set<string>();
   for (const [label, input] of iterateMapOrArrayLabeled(workflow.inputs)) {

--- a/packages/schema/test/draft-checks.test.ts
+++ b/packages/schema/test/draft-checks.test.ts
@@ -260,7 +260,7 @@ describe("validateDraft", () => {
     expect(r.topologyErrors).toEqual([]);
   });
 
-  it("emits semantic error on malformed TODO-shaped strings", () => {
+  it("emits semantic error on malformed TODO-shaped strings (TODO_, TODO-foo, TODO_Foo)", () => {
     const r = validateDraft({
       class: DRAFT_CLASS,
       inputs: { reads: { type: "data" } },
@@ -269,7 +269,7 @@ describe("validateDraft", () => {
         a: {
           tool_id: "TODO-foo",
           tool_version: "TODO_",
-          in: { TODOfoo: "reads" },
+          in: { TODO_input: "reads" }, // canonical, not malformed
           out: [{ id: "TODO_Foo" }],
         },
       },
@@ -280,10 +280,13 @@ describe("validateDraft", () => {
       expect.arrayContaining([
         expect.stringContaining(`tool_id "TODO-foo" is TODO-shaped but malformed`),
         expect.stringContaining(`tool_version "TODO_" is TODO-shaped but malformed`),
-        expect.stringContaining(`in: key "TODOfoo" is TODO-shaped but malformed`),
         expect.stringContaining(`out: id "TODO_Foo" is TODO-shaped but malformed`),
       ]),
     );
+    // `TODOfoo`-style strings (TODO followed by a letter, no separator) are
+    // NOT flagged — the heuristic only matches TODO followed by `_`, `-`,
+    // or end-of-string, to avoid false positives on unrelated identifiers
+    // like TODONE / TODOLIST.
   });
 
   it("warns on bare TODO in port position", () => {
@@ -516,5 +519,153 @@ describe("nextDraftStep", () => {
       "TODO[in.TODO]: assign the real wrapper input port name",
       "TODO[out.TODO]: assign the real wrapper output port name",
     ]);
+  });
+});
+
+describe("fix-ups (review feedback)", () => {
+  // Reviewer #1: list-form `in:` and `out:` shapes.
+  it("detectDraft picks up TODO sentinels in list-form `in:` entries", () => {
+    const survey = detectDraft({
+      class: DRAFT_CLASS,
+      steps: {
+        fastp: {
+          tool_id: "TODO",
+          tool_version: "TODO",
+          in: [{ id: "TODO_input", source: "reads" }],
+          out: [{ id: "TODO_trimmed" }],
+        },
+      },
+    });
+    const kinds = survey.todos.map((t) => t.location.kind);
+    expect(kinds).toContain("in_key");
+    const inHit = survey.todos.find((t) => t.location.kind === "in_key");
+    expect(inHit?.sentinel).toBe("TODO_input");
+  });
+
+  it("detectDraft picks up TODO sentinels in list-form `out:` (already worked, locking in)", () => {
+    const survey = detectDraft({
+      class: DRAFT_CLASS,
+      steps: {
+        a: { tool_id: "TODO", tool_version: "TODO", out: [{ id: "TODO_x" }, { id: "TODO_y" }] },
+      },
+    });
+    const outIds = survey.todos
+      .filter((t) => t.location.kind === "out_id")
+      .map((t) => (t.location.kind === "out_id" ? t.location.id : ""));
+    expect(outIds).toEqual(["TODO_x", "TODO_y"]);
+  });
+
+  it("validateDraft picks up dangling edge refs in list-form `in:` entries", () => {
+    const r = validateDraft({
+      class: DRAFT_CLASS,
+      inputs: { reads: { type: "data" } },
+      outputs: {},
+      steps: {
+        a: {
+          tool_id: "cat1",
+          tool_version: "1.0.0",
+          in: [{ id: "input1", source: "missing/out1" }],
+          out: [{ id: "out1" }],
+        },
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.topologyErrors.map((e) => e.message)).toContain(
+      `step input "input1" source "missing/out1" references unknown step "missing"`,
+    );
+  });
+
+  // Reviewer #2: top-level _plan_* warning at INNER draft roots.
+  it("validateDraft warns about _plan_* at inner draft subworkflow roots, with the outer step's path", () => {
+    const r = validateDraft({
+      class: DRAFT_CLASS,
+      inputs: { reads: { type: "data" } },
+      outputs: {},
+      steps: {
+        outer: {
+          type: "subworkflow",
+          in: { reads: "reads" },
+          out: [{ id: "result" }],
+          run: {
+            class: DRAFT_CLASS,
+            _plan_context: "settle the inner workflow",
+            inputs: { reads: { type: "data" } },
+            outputs: {},
+            steps: { inner: { tool_id: "cat1", tool_version: "1.0.0" } },
+          },
+        },
+      },
+    });
+    // Outer has no _plan_*; inner does. Expect exactly one warning.
+    const planWarnings = r.warnings.filter((w) => w.message.includes("_plan_context"));
+    expect(planWarnings).toHaveLength(1);
+    expect(planWarnings[0]?.path).toEqual(["outer"]);
+  });
+
+  // Reviewer #5: tighter TODO_LIKE regex no longer false-positives on TODONE/TODOLIST.
+  it("validateDraft does NOT flag identifiers that merely start with TODO", () => {
+    const r = validateDraft({
+      class: DRAFT_CLASS,
+      inputs: { reads: { type: "data" } },
+      outputs: {},
+      steps: {
+        TODONE_step: {
+          tool_id: "TODONE",
+          tool_version: "TODOLIST",
+          in: { TODONE: "reads" },
+          out: [{ id: "TODOLIST" }],
+        },
+      },
+    });
+    expect(r.semanticErrors).toEqual([]);
+  });
+
+  // Reviewer #6: ordering idempotence — different dict insertion orders produce identical nextDraftStep output.
+  it("nextDraftStep is byte-for-byte identical across two semantically-equal workflows with different dict key order", () => {
+    const wfA = {
+      class: DRAFT_CLASS,
+      inputs: { reads: { type: "data" } },
+      outputs: {},
+      steps: {
+        alpha: { tool_id: "TODO", tool_version: "TODO", in: { x: "reads" } },
+        zulu: { tool_id: "TODO", tool_version: "TODO", in: { x: "reads" } },
+      },
+    };
+    // Same content, opposite insertion order.
+    const wfB = {
+      class: DRAFT_CLASS,
+      outputs: {},
+      inputs: { reads: { type: "data" } },
+      steps: {
+        zulu: { tool_id: "TODO", tool_version: "TODO", in: { x: "reads" } },
+        alpha: { tool_id: "TODO", tool_version: "TODO", in: { x: "reads" } },
+      },
+    };
+    expect(JSON.stringify(nextDraftStep(wfA))).toBe(JSON.stringify(nextDraftStep(wfB)));
+  });
+
+  // Reviewer #4: clarify inner-draft outputs path.
+  it("detectDraft uses the outer-step path for inner-draft workflow outputs", () => {
+    const survey = detectDraft({
+      class: DRAFT_CLASS,
+      steps: {
+        outer: {
+          type: "subworkflow",
+          run: {
+            class: DRAFT_CLASS,
+            outputs: { result: { outputSource: "inner_step/TODO_port" } },
+            steps: {
+              inner_step: { tool_id: "cat1", tool_version: "1.0.0", out: [{ id: "TODO_port" }] },
+            },
+          },
+        },
+      },
+    });
+    const outputHit = survey.todos.find((t) => t.location.kind === "output_source");
+    expect(outputHit?.path).toEqual(["outer"]);
+    if (outputHit?.location.kind === "output_source") {
+      expect(outputHit.location.output_label).toBe("result");
+      expect(outputHit.location.port).toBe("TODO_port");
+    }
   });
 });


### PR DESCRIPTION
Stacked on #100. Addresses blocking + a couple of important findings from an independent review of the draft-checks substrate landing on that PR.

## Fixes

1. **List-form \`in:\` coverage in \`detectDraft\`.** \`collectStepTodos\` only walked dict-form \`step.in\`; list-form (\`in: [{ id: \"TODO_x\", source: ... }]\`) was silently missed. Now uses the same \`iterateStepInputEntries\` iterator \`validateDraft\` has used since commit 2. Fixes cross-function asymmetry where \`validateDraft\` would surface a malformed-sentinel error for a list-form \`id\` but \`detectDraft\` / \`nextDraftStep\` would never see it.

2. **Inner draft root \`_plan_*\` warning in \`validateDraft\`.** The "top-level \`_plan_*\` is not part of the draft contract" warning only fired against the outermost workflow root. Inner draft subworkflows reached via recursion were silent. Moved the check into \`walkDraftValidation\` so it fires at every draft root, with the correct outer-step path on diagnostics.

3. **Tightened \`TODO_LIKE\` heuristic.** Was \`/^TODO/\`, which false-positived on identifiers like \`TODONE\` and \`TODOLIST\`. Now \`/^TODO([_-]|$)/\` — only matches \`TODO\` followed by \`_\`, \`-\`, or end-of-string. Updated one pre-existing test that asserted \`TODOfoo\` would be flagged (now documented as intentionally accepted).

4. **Documentation comments** on two intentional design choices a future reader might want to "fix":
   - \`detectDraft\` is step-focused and ignores top-level \`_plan_*\`; \`validateDraft\` is rules-focused and warns. The asymmetry is intentional.
   - Inner-draft outputs collect at \`path = outer step path\` (mirrors how subworkflow steps reach their inner workflow).

## Test plan

- [x] 7 new vitest cases covering each fix-up:
  - list-form \`in:\` sentinel collection
  - list-form \`out:\` sentinel collection (locking in pre-existing behavior)
  - dangling edge ref through list-form \`in:\`
  - inner-draft \`_plan_*\` warning with outer-step path
  - identifiers starting with \`TODO\` but not malformed sentinels (TODONE etc.)
  - input-ordering idempotence: two semantically-equal workflows with different dict insertion order produce identical \`nextDraftStep\` output
  - inner-draft outputs path documented
- [x] All 47 \`draft-checks.test.ts\` cases pass
- [x] \`make check && make test\` green

## Followup

Reviewer's "important" findings not addressed here (deferred to be folded into commit 4 / 5 of subplan B, or filed as their own PR):

- \`iterateMapOrArrayLabeled\` is a single-call alias for \`iterateOutputs\` — inline or rename.
- Sentinel drift regex in \`scripts/check-draft-sentinel.mjs\` is brittle to upstream reformatting (works today).
- \`DraftWorkflowStepSchema\` redeclares every \`WorkflowStep\` field after \`...WorkflowStepSchema.fields\` — generator artifact worth an upstream issue.
- Test file path is \`packages/schema/test/draft-checks.test.ts\`; subplan B suggested \`test/workflow/draft-checks.test.ts\`. Cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)