### PR TITLE
feat(schema): export galaxyWorkflowDraftJsonSchema (#108)

### DIFF
--- a/.changeset/draft-json-schema-export.md
+++ b/.changeset/draft-json-schema-export.md
@@ -1,0 +1,5 @@
+---
+"@galaxy-tool-util/schema": minor
+---
+
+Export `galaxyWorkflowDraftJsonSchema` — a plain JSON-Schema (2020-12) sibling of `GalaxyWorkflowDraftSchema`. Effect schema values are functions and do not survive `JSON.stringify`; the new export lets downstream packagers (e.g. Foundry's cast pipeline) bundle the draft schema verbatim. Closes #108.

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -90,6 +90,8 @@ export {
   type GalaxyWorkflowDraft,
   /** Relaxed format2 schema for in-progress drafts; permits TODO sentinels and `_plan_*` planning fields. */
   GalaxyWorkflowDraftSchema,
+  /** Plain JSON Schema (2020-12) sibling of `GalaxyWorkflowDraftSchema` — survives `JSON.stringify` for downstream packagers. */
+  galaxyWorkflowDraftJsonSchema,
   type DraftWorkflowStep,
   /** Schema for a single step inside a GalaxyWorkflowDraft; relaxed vs. the concrete step schema. */
   DraftWorkflowStepSchema,

--- a/packages/schema/src/workflow/index.ts
+++ b/packages/schema/src/workflow/index.ts
@@ -13,6 +13,9 @@ export {
   NativeGalaxyWorkflowSchema,
 } from "./raw/index.js";
 
+// Plain JSON Schema siblings for downstream packagers (issue #108)
+export { galaxyWorkflowDraftJsonSchema } from "./json-schemas.js";
+
 // Normalized workflow types + normalizers
 export {
   normalizedFormat2,

--- a/packages/schema/src/workflow/json-schemas.ts
+++ b/packages/schema/src/workflow/json-schemas.ts
@@ -1,0 +1,39 @@
+/**
+ * Plain JSON Schema siblings of the Effect workflow schemas.
+ *
+ * Effect `Schema.Schema<A>` values are functions and do not survive
+ * `JSON.stringify`; downstream packagers that copy a schema verbatim into a
+ * runtime bundle need a plain-object JSON Schema instead. Mirrors the
+ * `parsedToolSchema` pattern in `schema/parsed-tool.ts`.
+ */
+
+import { JSONSchema } from "effect";
+
+import { GalaxyWorkflowDraftSchema } from "./raw/gxformat2-draft.effect.js";
+
+/**
+ * Effect's `JSONSchema.make` emits inline `{$id: "/schemas/unknown", ...}`
+ * nodes wherever it encounters `Schema.Unknown` / `Schema.Any`. The draft
+ * schema hits this dozens of times (free-form `state`, `tool_state`,
+ * `default`, post-job actions, etc.), and Ajv refuses to compile a document
+ * with the same `$id` resolving to multiple distinct nodes. Stripping the
+ * `$id` leaves the node semantically equivalent (still accepts anything)
+ * and lets standard JSON Schema validators load the result.
+ */
+function stripDuplicateUnknownIds(node: unknown): void {
+  if (node === null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) stripDuplicateUnknownIds(item);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  if (obj.$id === "/schemas/unknown") delete obj.$id;
+  for (const k of Object.keys(obj)) stripDuplicateUnknownIds(obj[k]);
+}
+
+const draftJsonSchema = JSONSchema.make(GalaxyWorkflowDraftSchema, {
+  target: "jsonSchema2020-12",
+}) as object;
+stripDuplicateUnknownIds(draftJsonSchema);
+
+export const galaxyWorkflowDraftJsonSchema = draftJsonSchema;

--- a/packages/schema/test/workflow-json-schemas.test.ts
+++ b/packages/schema/test/workflow-json-schemas.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Verifies the plain JSON Schema sibling of `GalaxyWorkflowDraftSchema`
+ * (issue #108) — survives `JSON.stringify` and round-trips through Ajv
+ * against known-good and known-bad fixtures.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import { describe, expect, it } from "vitest";
+
+import Ajv2020Import from "ajv/dist/2020.js";
+import addFormatsImport from "ajv-formats";
+
+import { galaxyWorkflowDraftJsonSchema } from "../src/workflow/json-schemas.js";
+
+const Ajv2020 = Ajv2020Import as unknown as typeof Ajv2020Import.default;
+const addFormats = addFormatsImport as unknown as typeof addFormatsImport.default;
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(here, "fixtures", "workflows", "format2", "draft");
+function loadFixture(name: string): unknown {
+  return parseYaml(fs.readFileSync(path.join(fixturesDir, name), "utf-8"));
+}
+
+describe("galaxyWorkflowDraftJsonSchema", () => {
+  it("is a plain JSON object that survives JSON.stringify", () => {
+    const serialized = JSON.stringify(galaxyWorkflowDraftJsonSchema);
+    expect(serialized.length).toBeGreaterThan(0);
+    expect(serialized).not.toBe("undefined");
+    const reparsed = JSON.parse(serialized);
+    expect(reparsed).toMatchObject({
+      $schema: expect.stringContaining("2020-12"),
+      type: "object",
+    });
+  });
+
+  it("compiles under Ajv 2020-12", () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(galaxyWorkflowDraftJsonSchema as object);
+    expect(typeof validate).toBe("function");
+  });
+
+  it("accepts a known-good draft workflow fixture", () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(galaxyWorkflowDraftJsonSchema as object);
+    const draft = loadFixture("synthetic-draft-tool-step.gxwf.yml");
+    const ok = validate(draft);
+    if (!ok) {
+      // surface the first few errors for debuggability
+      console.error(validate.errors?.slice(0, 5));
+    }
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a malformed draft (wrong `class` literal)", () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(galaxyWorkflowDraftJsonSchema as object);
+    const bad = { class: "NotADraft", steps: [] };
+    expect(validate(bad)).toBe(false);
+  });
+});


### PR DESCRIPTION
> Posted by Claude (AI assistant) on jmchilton's behalf.

Closes #108.

## Summary

- Adds `galaxyWorkflowDraftJsonSchema` — a plain JSON Schema (2020-12) sibling of `GalaxyWorkflowDraftSchema`, exported from the package root.
- Built via `JSONSchema.make` (matches the `parsedToolSchema` pattern), with one workaround: strips the inlined `$id: "/schemas/unknown"` that Effect emits for every `Schema.Unknown`/`Schema.Any` site (~88 across the draft schema). Same `$id` resolving to multiple distinct nodes breaks Ajv; stripping it keeps the nodes semantically equivalent (still accepts anything).
- Hand-written file at `packages/schema/src/workflow/json-schemas.ts` so re-generation of `raw/` doesn't clobber it.

## Acceptance (from #108)

- [x] `import { galaxyWorkflowDraftJsonSchema } from "@galaxy-tool-util/schema"` returns a plain JSON-Schema object.
- [x] `JSON.stringify(galaxyWorkflowDraftJsonSchema)` produces a non-empty string (~97KB).
- [x] Validates a known-good `class: GalaxyWorkflowDraft` fixture; rejects a malformed one.

## Test plan

- [x] `make test` — full suite green (4893 schema tests pass, including 4 new in `workflow-json-schemas.test.ts`).
- [x] `make check` — lint, format, typecheck green.
- [x] Ajv 2020-12 compiles the schema and validates a fixture (`synthetic-draft-tool-step.gxwf.yml`).

## Out of scope (follow-up)

Issue's secondary asks — `galaxyWorkflowJsonSchema`, `nativeGalaxyWorkflowJsonSchema`, and the `NormalizedFormat2*` family — will need similar treatment but those schemas may need additional `identifier` annotations on their suspended self-refs before `JSONSchema.make` succeeds. Tracking separately so this primary export can ship.