### PR TITLE
feat(schema): drop disconnected-optional RuntimeValue in stateful conversion (Phase 2 TS)

### DIFF
--- a/.changeset/drop-disconnected-optional-runtime.md
+++ b/.changeset/drop-disconnected-optional-runtime.md
@@ -1,0 +1,14 @@
+---
+"@galaxy-tool-util/schema": patch
+"@galaxy-tool-util/cli": patch
+---
+
+Stateful conversion: drop disconnected-optional `RuntimeValue` markers and stop double-stamping connected params.
+
+`convertStateToFormat2` now evaluates each leaf connection-first with an early return, then gates `RuntimeValue` handling on optionality (mirrors Galaxy's Phase 1 converter change):
+
+- A `RuntimeValue` on an **optional, disconnected** leaf is omitted entirely — no state key and, crucially, no phantom `in:` connection claiming `source: "runtime_value"`. This is native authored content (a real optional input the user left unset), not a missed connection, so format2 should carry no trace of it. Verified against the IWC `average-bigwig-between-replicates` workflow, whose `advancedOpt|blackListFileName` now drops cleanly.
+- A `RuntimeValue` on a **required, disconnected** leaf still records the placeholder (correct `workflow_step_linked` behavior).
+- A leaf that is **connected** — via `input_connections` or a `ConnectedValue` marker — is always treated as a pure connection, even when the native state also carries a stray `RuntimeValue` marker (legacy workflows do this). The previous empty-`if`/fall-through double-stamped these with a runtime placeholder.
+
+Roundtrip diffing already classifies a dropped optional `RuntimeValue` as benign (`connection_only_section_omitted`), so no roundtrip change was needed.

--- a/packages/integration-tests/test/disconnected-optional-runtime.test.ts
+++ b/packages/integration-tests/test/disconnected-optional-runtime.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Real-corpus integration test for the disconnected-optional RuntimeValue drop.
+ *
+ * Converts the IWC `average-bigwig-between-replicates` workflow via
+ * `toFormat2Stateful` and asserts the optional, disconnected
+ * `advancedOpt|blackListFileName` RuntimeValue leaves no trace — neither a
+ * state key nor a phantom `in:` connection (`source: "runtime_value"`). Mirrors
+ * Galaxy's Phase 1 converter change. Skips when the local ToolShed tool cache
+ * (`~/.galaxy/tool_info_cache`) lacks the deeptools tool, matching the
+ * skip-if-no-cache convention of the declarative wfstate tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+import { toFormat2Stateful, type ToolInputsResolver } from "@galaxy-tool-util/schema";
+import { getCacheDir, makeNodeToolCache } from "@galaxy-tool-util/core/node";
+
+// Vendored IWC source lives under the gxwf-e2e workspace seed; reuse it rather
+// than duplicating the workflow. Loud failure if it moves is intentional.
+const WORKFLOW_PATH = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "gxwf-e2e",
+  "fixtures",
+  "workspace-seed",
+  "iwc",
+  "average-bigwig-between-replicates.ga",
+);
+
+const DEEPTOOLS_FRAGMENT = "deeptools_bigwig_average";
+
+function toolCacheAvailable(): boolean {
+  const dir = getCacheDir();
+  return fs.existsSync(dir) && fs.readdirSync(dir).some((f) => f.endsWith(".json"));
+}
+
+/** Sync resolver backed by the node tool cache (mirrors declarative-wfstate). */
+function makeResolver(): ToolInputsResolver {
+  const cache = makeNodeToolCache();
+  const cacheDir = getCacheDir();
+  return (toolId: string, toolVersion: string | null) => {
+    const coords = cache.resolveToolCoordinates(toolId, toolVersion);
+    const version = coords.version ?? "_default_";
+    const key = createHash("sha256")
+      .update(`${coords.toolshedUrl}/${coords.trsToolId}/${version}`)
+      .digest("hex");
+    const filePath = join(cacheDir, `${key}.json`);
+    if (!fs.existsSync(filePath)) return undefined;
+    try {
+      return JSON.parse(fs.readFileSync(filePath, "utf-8")).inputs ?? [];
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+describe("disconnected-optional RuntimeValue (real IWC corpus)", () => {
+  it.skipIf(!toolCacheAvailable())(
+    "drops advancedOpt|blackListFileName with no state key and no phantom in:",
+    () => {
+      const raw = JSON.parse(fs.readFileSync(WORKFLOW_PATH, "utf-8"));
+      const result = toFormat2Stateful(raw, makeResolver());
+
+      const deeptools = result.workflow.steps.find((s) => s.tool_id?.includes(DEEPTOOLS_FRAGMENT));
+      expect(deeptools, "deeptools_bigwig_average step present").toBeDefined();
+
+      // The step must have converted statefully (no fallback to raw tool_state).
+      const status = result.steps.find((s) => s.toolId?.includes(DEEPTOOLS_FRAGMENT));
+      expect(status?.converted).toBe(true);
+      expect(status?.failureClass).toBeUndefined();
+
+      const inBlock = (deeptools?.in ?? []) as Array<{ id: string; source: string }>;
+      // No phantom runtime placeholder connection survived the conversion.
+      expect(inBlock.some((e) => e.source === "runtime_value")).toBe(false);
+      // The optional disconnected leaf is gone from the `in:` block entirely.
+      expect(inBlock.some((e) => e.id.includes("blackListFileName"))).toBe(false);
+      // ...and from format2 state.
+      const advancedOpt = (deeptools?.state?.advancedOpt ?? {}) as Record<string, unknown>;
+      expect("blackListFileName" in advancedOpt).toBe(false);
+
+      // Sanity: the real connections in the same step are preserved.
+      expect(inBlock.some((e) => e.id === "advancedOpt|binSize")).toBe(true);
+      expect(inBlock.some((e) => e.id === "bigwigs")).toBe(true);
+    },
+  );
+});

--- a/packages/schema/src/workflow/stateful-convert.ts
+++ b/packages/schema/src/workflow/stateful-convert.ts
@@ -97,6 +97,11 @@ export interface Format2ConvertedState {
 /** Data parameter types — always go to `in` block, never to state. */
 const DATA_PARAM_TYPES = new Set(["gx_data", "gx_data_collection"]);
 
+/** Read `optional` defensively — CWL parameter models lack the field. */
+function isOptionalParam(toolInput: ToolParameterModel): boolean {
+  return (toolInput as { optional?: boolean }).optional === true;
+}
+
 /**
  * Convert a native step's tool_state to format2 state + in block.
  *
@@ -120,13 +125,18 @@ export function convertStateToFormat2(
   const leafCallback: LeafCallback = (toolInput, value, statePath) => {
     const paramType = toolInput.parameter_type;
 
-    // Data parameters: always to `in` block
+    // Data parameters: never to state. Connection wins over any marker.
     if (DATA_PARAM_TYPES.has(paramType)) {
-      if (isConnectedValue(value) || connectedPaths.has(statePath)) {
+      if (connectedPaths.has(statePath) || isConnectedValue(value)) {
         // Connected data param — recorded via input_connections, handled by structural conversion
+        return SKIP_VALUE;
       }
       if (isRuntimeValue(value)) {
-        inBlock[statePath] = "runtime_value";
+        // Disconnected runtime: keep placeholder only when required; omit when optional.
+        if (!isOptionalParam(toolInput)) {
+          inBlock[statePath] = "runtime_value";
+        }
+        return SKIP_VALUE;
       }
       return SKIP_VALUE;
     }
@@ -149,15 +159,16 @@ export function convertStateToFormat2(
       return value;
     }
 
-    // ConnectedValue → record in `in` block, skip from state
-    if (isConnectedValue(value)) {
-      // Connection source handled by structural conversion's input_connections
+    // Connection wins over any marker — source handled by structural conversion.
+    if (connectedPaths.has(statePath) || isConnectedValue(value)) {
       return SKIP_VALUE;
     }
 
-    // RuntimeValue → record in `in` block, skip from state
+    // Disconnected runtime: keep placeholder only when required; omit when optional.
     if (isRuntimeValue(value)) {
-      inBlock[statePath] = "runtime_value";
+      if (!isOptionalParam(toolInput)) {
+        inBlock[statePath] = "runtime_value";
+      }
       return SKIP_VALUE;
     }
 

--- a/packages/schema/test/roundtrip.test.ts
+++ b/packages/schema/test/roundtrip.test.ts
@@ -85,6 +85,22 @@ function textParam(name: string): TextParameterModel {
   };
 }
 
+function dataParam(name: string, optional: boolean): ToolParameterModel {
+  return {
+    name,
+    parameter_type: "gx_data",
+    type: "data",
+    hidden: false,
+    label: null,
+    help: null,
+    argument: null,
+    is_dynamic: false,
+    optional,
+    multiple: false,
+    extensions: ["data"],
+  } as ToolParameterModel;
+}
+
 // --- Fixtures ---
 
 /**
@@ -237,6 +253,45 @@ describe("roundtripValidate", () => {
     expect(result.success).toBe(false);
     expect(result.stepResults[0].failureClass).toBe("conversion_error");
     expect(result.forwardSteps[0].converted).toBe(false);
+  });
+
+  it("optional disconnected RuntimeValue dropped in conversion is benign", () => {
+    // The converter omits a RuntimeValue marker on an optional, disconnected
+    // data param (no phantom `in:` entry). Round-trip: the marker is present
+    // in the original native state but absent after, and the differ must
+    // classify the drop as benign (connection_only_section_omitted), not error.
+    const inputs = [...coolToolInputs(), dataParam("ref", true)];
+    const wf = nativeWorkflow({
+      count: 42,
+      enabled: true,
+      tags: ["a"],
+      label: "hi",
+      ref: { __class__: "RuntimeValue" },
+    });
+    const result = roundtripValidate(wf, mapResolver({ cool_tool: inputs }));
+    expect(result.success).toBe(true);
+    const errorDiffs = result.stepResults[0].diffs.filter((d) => d.severity === "error");
+    expect(errorDiffs).toEqual([]);
+    const refDiff = result.stepResults[0].diffs.find((d) => d.key_path === "ref");
+    expect(refDiff?.severity).toBe("benign");
+    expect(refDiff?.benign_artifact?.reason).toBe("connection_only_section_omitted");
+  });
+
+  it("required disconnected RuntimeValue keeps a placeholder (no benign drop)", () => {
+    // Control: a required param's RuntimeValue becomes an `in:` placeholder and
+    // is restored on reverse, so there is no dropped-key diff at all.
+    const inputs = [...coolToolInputs(), dataParam("ref", false)];
+    const wf = nativeWorkflow({
+      count: 42,
+      enabled: true,
+      tags: ["a"],
+      label: "hi",
+      ref: { __class__: "RuntimeValue" },
+    });
+    const result = roundtripValidate(wf, mapResolver({ cool_tool: inputs }));
+    expect(result.success).toBe(true);
+    const errorDiffs = result.stepResults[0].diffs.filter((d) => d.severity === "error");
+    expect(errorDiffs).toEqual([]);
   });
 
   it("clean=true when zero diffs of any severity", () => {

--- a/packages/schema/test/stateful-convert.test.ts
+++ b/packages/schema/test/stateful-convert.test.ts
@@ -510,20 +510,64 @@ describe("convertStateToFormat2", () => {
     expect(result.state).toEqual({ label: "test" });
   });
 
-  it("records RuntimeValue data params in `in` block", () => {
-    const inputs = [dataParam("input1")];
+  // Leaf decision table: connection-first early return, then RuntimeValue
+  // gated on optionality. Mirrors Python convert_leaf.
+
+  it("row: required disconnected data RuntimeValue → `in` placeholder", () => {
+    const inputs = [dataParam("input1")]; // optional: false
     const step = nativeStep({ input1: { __class__: "RuntimeValue" } });
     const result = convertStateToFormat2(step, inputs);
     expect(result.state).toEqual({});
     expect(result.in).toEqual({ input1: "runtime_value" });
   });
 
-  it("records RuntimeValue scalar params in `in` block", () => {
-    const inputs = [textParam("query")];
+  it("row: optional disconnected data RuntimeValue → omitted (no state, no `in`)", () => {
+    const inputs = [{ ...dataParam("input1"), optional: true }];
+    const step = nativeStep({ input1: { __class__: "RuntimeValue" } });
+    const result = convertStateToFormat2(step, inputs);
+    expect(result.state).toEqual({});
+    expect(result.in).toEqual({});
+  });
+
+  it("row: required disconnected scalar RuntimeValue → `in` placeholder", () => {
+    const inputs = [{ ...textParam("query"), optional: false }];
     const step = nativeStep({ query: { __class__: "RuntimeValue" } });
     const result = convertStateToFormat2(step, inputs);
     expect(result.state).toEqual({});
     expect(result.in).toEqual({ query: "runtime_value" });
+  });
+
+  it("row: optional disconnected scalar RuntimeValue → omitted", () => {
+    const inputs = [textParam("query")]; // optional: true
+    const step = nativeStep({ query: { __class__: "RuntimeValue" } });
+    const result = convertStateToFormat2(step, inputs);
+    expect(result.state).toEqual({});
+    expect(result.in).toEqual({});
+  });
+
+  it("row: connected data ConnectedValue → not in state, no runtime stamp", () => {
+    const inputs = [dataParam("input1")];
+    const step = nativeStep(
+      { input1: { __class__: "ConnectedValue" } },
+      { connectedPaths: ["input1"] },
+    );
+    const result = convertStateToFormat2(step, inputs);
+    expect(result.state).toEqual({});
+    expect(result.in).toEqual({});
+  });
+
+  it("row: legacy connected path carrying RuntimeValue marker → connection wins, not double-stamped", () => {
+    // optional data param connected via input_connections but tool_state still
+    // carries a RuntimeValue marker. Connection must win — no runtime omission,
+    // no `in` placeholder (structural conversion records the connection).
+    const inputs = [{ ...dataParam("input1"), optional: true }];
+    const step = nativeStep(
+      { input1: { __class__: "RuntimeValue" } },
+      { connectedPaths: ["input1"] },
+    );
+    const result = convertStateToFormat2(step, inputs);
+    expect(result.state).toEqual({});
+    expect(result.in).toEqual({});
   });
 
   it("skips ConnectedValue markers from state", () => {


### PR DESCRIPTION
## Phase 2 (TypeScript) — drop disconnected-optional `RuntimeValue` in stateful conversion

Mirrors the Python Phase 1 converter change (Galaxy `wf_tool_state`, `a51f975d11`). Driver is **conversion fidelity**, not "make validate pass" — #114 already fixed the validate symptom via native-path routing; the schema-aware conversion path it left untouched still emitted semantically-false shapes.

### What changed

`convertStateToFormat2`'s `leafCallback` now evaluates each leaf **connection-first with an early return**, then gates `RuntimeValue` on optionality:

| leaf condition | action |
|---|---|
| connected (`input_connections` or `ConnectedValue`) | pure connection → `SKIP`, even with a stray `RuntimeValue` marker |
| `RuntimeValue` **and** optional | omit entirely — no state key, no `in:` entry |
| `RuntimeValue` **and** required | keep `"runtime_value"` placeholder |
| literal | coerce scalar (unchanged) |

Applied to both the data and scalar branches. This fixes two defects:

1. **Phantom `in:` connection.** A disconnected-optional `RuntimeValue` on an optional `gx_data` param no longer becomes `in: {id: path, source: "runtime_value"}` — a format2 connection claiming a source named `"runtime_value"`. It is native authored content (a real optional input left unset), so format2 carries no trace of it. (~291 IWC sites.)
2. **Legacy double-stamp.** A *connected* param carrying a `RuntimeValue` marker is now treated as a pure connection instead of getting a phantom runtime placeholder. The previous empty-`if`/fall-through stamped both. (~79 IWC sites.)

Roundtrip diffing already classifies a dropped optional `RuntimeValue` as benign (`connection_only_section_omitted`), so **no roundtrip change was needed** (matches Python, where this was also a no-op).

### Tests

- **Unit** (`stateful-convert.test.ts`): the five decision-table rows, incl. the legacy-connected-with-`RuntimeValue` case and the optional-disconnected omit.
- **Roundtrip** (`roundtrip.test.ts`): optional-disconnected drop classified benign end-to-end + required-control.
- **Integration** (`integration-tests/.../disconnected-optional-runtime.test.ts`): converts the real IWC `average-bigwig-between-replicates.ga` via `toFormat2Stateful`; asserts `advancedOpt|blackListFileName` leaves no state key and no `source: "runtime_value"` connection, while the real connections (`binSize`, `bigwigs`) survive. Skip-if-no-cache; **verified red→green against the live deeptools cache**.

`make check` and `make test` both green. Changeset (`schema` + `cli`, patch) included.

### Notes
- **Scope:** omission applies to all leaf types (data + scalar), matching Python which gates both branches.
- **Goldens:** `make sync-wfstate-expectations` produces **no diff** — neither the TS nor Galaxy expectation fixtures exercise a disconnected-optional `RuntimeValue`, so the integration test (not goldens) is the real-corpus coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
