### PR TITLE
Format2 JSON Schema linked-validation parity + run IWC sweeps in CI

### DIFF
--- a/.changeset/format2-jsonschema-linked-parity.md
+++ b/.changeset/format2-jsonschema-linked-parity.md
@@ -1,0 +1,10 @@
+---
+"@galaxy-tool-util/schema": patch
+"@galaxy-tool-util/cli": patch
+---
+
+Fix format2 two-level JSON Schema validation to match Galaxy:
+
+- A connected `multiple` select now validates against `workflow_step_linked`. `injectConnectionsIntoState` gained a `{ linked: true }` option that encodes the marker as a single-element list `[{ConnectedValue}]` (the linked select-multiple schema accepts ConnectedValue only as an array item, per `parameter_specification.yml`), instead of the bare `{ConnectedValue}` that the schema rejected.
+- `validateFormat2StepsJsonSchema` no longer crashes (`"/schemas/unknown" resolves to more than one schema`) on tools with two or more unknown/any params — each schema compiles in its own ajv instance with `$id` stripped.
+- Structural JSON Schema validation is non-strict (additional properties allowed) and unmatched connection keys (e.g. the `when` gate) are tolerated, matching Python's `validate_workflow_json_schema`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -43,6 +44,42 @@ jobs:
         with:
           name: playwright-report
           path: packages/gxwf-e2e/playwright-report/
+
+  iwc-sweep:
+    runs-on: ubuntu-latest
+    env:
+      GALAXY_TEST_IWC_DIRECTORY: ${{ github.workspace }}/iwc
+      GALAXY_TOOL_CACHE_DIR: ${{ github.workspace }}/.iwc-tool-cache
+      # Pinned IWC corpus — keeps the sweep deterministic and the tool cache
+      # reusable. Bump alongside the sweep allowlists (STRICT_STRUCTURE_SKIP,
+      # KNOWN_INVALID_TESTS_FILES, KNOWN_ROUNDTRIP_FAILURES) when the corpus drifts.
+      IWC_REF: ed959c92a4b70ea5bc09d999df833f7566e9eee3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+      - name: Checkout IWC corpus
+        uses: actions/checkout@v4
+        with:
+          repository: galaxyproject/iwc
+          ref: ${{ env.IWC_REF }}
+          path: iwc
+      - name: Restore tool cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.GALAXY_TOOL_CACHE_DIR }}
+          key: iwc-tool-cache-v1-${{ env.IWC_REF }}
+          restore-keys: iwc-tool-cache-v1-
+      # Populate any tools missing from the (possibly partial) restored cache.
+      # Idempotent: cached tools are skipped; only cache misses hit the ToolShed.
+      - name: Populate tool cache
+        run: |
+          find "$GALAXY_TEST_IWC_DIRECTORY/workflows" -name '*.ga' -print0 \
+            | while IFS= read -r -d '' wf; do
+                node packages/cli/dist/bin/galaxy-tool-cache.js populate-workflow "$wf" || true
+              done
+      - name: Run IWC sweeps
+        run: pnpm --filter @galaxy-tool-util/cli exec vitest run test/iwc-sweep.test.ts test/stateful-iwc-sweep.test.ts
 
   changeset-check:
     runs-on: ubuntu-latest

--- a/packages/cli/src/commands/validate-workflow-json-schema.ts
+++ b/packages/cli/src/commands/validate-workflow-json-schema.ts
@@ -46,17 +46,46 @@ import { isEmptyState } from "./validate-workflow.js";
 import { isResolveError, loadCachedTool } from "./resolve-tool.js";
 
 const Ajv = (Ajv2020 as any).default ?? Ajv2020;
-const ajv = new Ajv({ allErrors: true, strict: false }) as any;
+
+// Recursively drop `$id` keys. Effect's JSONSchema.make inlines unknown/any
+// params as `{$id: "/schemas/unknown", title: "unknown"}` (and `/schemas/any`)
+// — a leaf that matches anything. A tool with two such params emits the same
+// `$id` twice in one schema, and AJV rejects duplicate `$id` registration with
+// "resolves to more than one schema". These ids are inlined (never `$ref`
+// targets) and `$defs` refs use JSON-pointer paths, so stripping `$id` is safe.
+function stripIds(schema: unknown): unknown {
+  if (schema === null || typeof schema !== "object") return schema;
+  if (Array.isArray(schema)) return schema.map(stripIds);
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    if (key === "$id") continue;
+    result[key] = stripIds(value);
+  }
+  return result;
+}
+
+// Compile a schema, stripping `$id` first (see stripIds). Each compile uses a
+// fresh Ajv instance so no cross-schema `$id`/`$ref` state leaks between tools.
+// Validators are cached by callers (module structural singletons +
+// _toolStateCache), so this runs once per unique schema.
+function compileSchema(schema: object): ValidateFunction {
+  const instance = new Ajv({ allErrors: true, strict: false }) as any;
+  return instance.compile(stripIds(schema)) as ValidateFunction;
+}
 
 // --- structural schema cache (generated once) ---
 
 let _nativeStructValidator: ValidateFunction | undefined;
 let _format2StructValidator: ValidateFunction | undefined;
 
+// Structural validation is non-strict (additionalProperties allowed), matching
+// Python's `_get_structural_validator(strict=False)` default — real workflows
+// carry extra envelope/step keys. The strict-structure axis is a separate path
+// (`checkStrictStructure`, Effect decode with onExcessProperty: "error").
 function nativeStructuralValidator(): ValidateFunction {
   if (!_nativeStructValidator) {
     const schema = JSONSchema.make(NativeGalaxyWorkflowSchema, { target: "jsonSchema2020-12" });
-    _nativeStructValidator = ajv.compile(schema as object) as ValidateFunction;
+    _nativeStructValidator = compileSchema(stripAdditionalProperties(schema) as object);
   }
   return _nativeStructValidator!;
 }
@@ -64,7 +93,7 @@ function nativeStructuralValidator(): ValidateFunction {
 function format2StructuralValidator(): ValidateFunction {
   if (!_format2StructValidator) {
     const schema = JSONSchema.make(GalaxyWorkflowSchema, { target: "jsonSchema2020-12" });
-    _format2StructValidator = ajv.compile(schema as object) as ValidateFunction;
+    _format2StructValidator = compileSchema(stripAdditionalProperties(schema) as object);
   }
   return _format2StructValidator!;
 }
@@ -106,7 +135,7 @@ function buildToolStateValidator(
   try {
     const jsonSchema = JSONSchema.make(effectSchema, { target: "jsonSchema2020-12" });
     const relaxed = stripAdditionalProperties(jsonSchema);
-    return ajv.compile(relaxed as object) as ValidateFunction;
+    return compileSchema(relaxed as object);
   } catch {
     return null;
   }
@@ -127,7 +156,7 @@ function loadToolStateValidatorFromDir(
   if (!existsSync(schemaPath)) return null;
   try {
     const raw = JSON.parse(readFileSync(schemaPath, "utf-8"));
-    return ajv.compile(raw);
+    return compileSchema(raw);
   } catch {
     return null;
   }
@@ -584,18 +613,12 @@ async function _validateFormat2StepJsonSchema(
   // Level 2: linked validation with connections injected
   if (Object.keys(connections).length > 0) {
     const linkedState = structuredClone(state);
-    const remaining = injectConnectionsIntoState(bundle.parameters, linkedState, connections);
-
-    const unmatchedKeys = Object.keys(remaining);
-    if (unmatchedKeys.length > 0) {
-      return {
-        step: stepLabel,
-        tool_id: toolId,
-        version: toolVersion,
-        status: "fail",
-        errors: unmatchedKeys.map((k) => `No parameter definition matching connection key "${k}"`),
-      };
-    }
+    // Unmatched connection keys (e.g. the synthetic `when` gate on conditional
+    // steps) are discarded, not failed — mirrors Python's
+    // validate_workflow_json_schema, which injects connections and ignores the
+    // returned unmatched paths. (The Pydantic path raises on unmatched; the
+    // JSON Schema path is intentionally lenient.)
+    injectConnectionsIntoState(bundle.parameters, linkedState, connections, { linked: true });
 
     const linkedValidate = getOrBuildValidator(
       toolId,

--- a/packages/cli/src/commands/validate-workflow.ts
+++ b/packages/cli/src/commands/validate-workflow.ts
@@ -522,7 +522,9 @@ async function _validateFormat2Step(
   // Level 2: Validate with connections injected against workflow_step_linked
   if (Object.keys(connections).length > 0) {
     const linkedState = structuredClone(state);
-    const remaining = injectConnectionsIntoState(bundle.parameters, linkedState, connections);
+    const remaining = injectConnectionsIntoState(bundle.parameters, linkedState, connections, {
+      linked: true,
+    });
 
     const unmatchedKeys = Object.keys(remaining);
     if (unmatchedKeys.length > 0) {

--- a/packages/cli/test/iwc-sweep.test.ts
+++ b/packages/cli/test/iwc-sweep.test.ts
@@ -25,6 +25,7 @@ import {
   type StepValidationResult,
 } from "../src/commands/validate-workflow.js";
 import { validateNativeStepsJsonSchema } from "../src/commands/validate-workflow-json-schema.js";
+import { lintWorkflowReport } from "../src/commands/lint.js";
 
 const IWC_DIR = process.env.GALAXY_TEST_IWC_DIRECTORY;
 
@@ -115,6 +116,16 @@ runSweep("native JSON Schema validation", validateNativeStepsJsonSchema);
 
 // --- Strict sweep suites ---
 
+// Older IWC workflows with deprecated position sub-fields (bottom, height,
+// right, width, x, y) intentionally dropped from the strict structure model.
+// Keep in sync with test_iwc_sweep.py _STRICT_STRUCTURE_SKIP.
+const STRICT_STRUCTURE_SKIP: ReadonlySet<string> = new Set([
+  "computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga",
+  "computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga",
+  "sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation.ga",
+  "sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation.ga",
+]);
+
 describe.skipIf(!IWC_DIR)("IWC sweep: strict-encoding", { timeout: 300_000 }, () => {
   let workflows: string[];
 
@@ -159,6 +170,7 @@ describe.skipIf(!IWC_DIR)("IWC sweep: strict-structure", { timeout: 300_000 }, (
   it("all IWC native workflows pass strict-structure", () => {
     const failures: Array<{ workflow: string; errors: string[] }> = [];
     for (const wfPath of workflows) {
+      if (STRICT_STRUCTURE_SKIP.has(workflowId(wfPath))) continue;
       const raw = readFileSync(wfPath, "utf-8");
       let data: Record<string, unknown>;
       try {
@@ -194,6 +206,7 @@ describe.skipIf(!IWC_DIR)("IWC sweep: strict (all)", { timeout: 300_000 }, () =>
     let skippedSteps = 0;
 
     for (const wfPath of workflows) {
+      if (STRICT_STRUCTURE_SKIP.has(workflowId(wfPath))) continue;
       const raw = readFileSync(wfPath, "utf-8");
       let data: Record<string, unknown>;
       try {
@@ -231,6 +244,67 @@ describe.skipIf(!IWC_DIR)("IWC sweep: strict (all)", { timeout: 300_000 }, () =>
         .map((f) => `  ${f.workflow} [${f.phase}]: ${f.errors.join("; ")}`)
         .join("\n");
       expect.fail(`${failures.length} strict failures:\n${details}`);
+    }
+  });
+});
+
+// --- Lint-stateful sweep ---
+
+// Run the unified lint pipeline (structural + best-practices + tool-state
+// validation) over every IWC native workflow. Mirrors Python
+// TestIWCSweepLintStateful: the bar is "lint runs to completion without
+// crashing." Lint warnings/errors and uncached-tool state skips are expected
+// on a real corpus and are reported, not failed.
+describe.skipIf(!IWC_DIR)("IWC sweep: lint-stateful", { timeout: 600_000 }, () => {
+  let workflows: string[];
+  let cache: ToolCache;
+
+  beforeAll(async () => {
+    workflows = await discoverNativeWorkflows(join(IWC_DIR!, "workflows"));
+    cache = makeNodeToolCache();
+    await cache.index.load();
+  });
+
+  it("lints all native workflows without crashing", async () => {
+    const crashes: Array<{ workflow: string; error: string }> = [];
+    let lintErrors = 0;
+    let lintWarnings = 0;
+    let stateValidated = 0;
+    let stateSkipped = 0;
+    let stateFailed = 0;
+
+    for (const wfPath of workflows) {
+      const id = workflowId(wfPath);
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(readFileSync(wfPath, "utf-8"));
+      } catch {
+        continue;
+      }
+      try {
+        const report = await lintWorkflowReport(wfPath, data, "native", { cache });
+        lintErrors += report.structural.error_count + (report.bestPractices?.error_count ?? 0);
+        lintWarnings += report.structural.warn_count + (report.bestPractices?.warn_count ?? 0);
+        for (const r of report.stateValidation ?? []) {
+          if (SKIP_STATUSES.has(r.status)) stateSkipped++;
+          else if (r.status === "fail") stateFailed++;
+          else stateValidated++;
+        }
+      } catch (err) {
+        crashes.push({ workflow: id, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    console.log(
+      `\nIWC lint-stateful sweep: ${workflows.length} workflows, ${lintErrors} lint errors, ${lintWarnings} lint warnings`,
+    );
+    console.log(
+      `  tool state: ${stateValidated} validated, ${stateSkipped} skipped, ${stateFailed} failed`,
+    );
+
+    if (crashes.length > 0) {
+      const details = crashes.map((c) => `  ${c.workflow}: ${c.error}`).join("\n");
+      expect.fail(`${crashes.length} workflow(s) crashed during lint:\n${details}`);
     }
   });
 });

--- a/packages/cli/test/stateful-iwc-sweep.test.ts
+++ b/packages/cli/test/stateful-iwc-sweep.test.ts
@@ -19,12 +19,18 @@ import type { ToolCache } from "@galaxy-tool-util/core";
 import { makeNodeToolCache } from "@galaxy-tool-util/core/node";
 import {
   roundtripValidate,
+  toFormat2Stateful,
+  SKIP_STATUSES,
   type BenignArtifactKind,
   type ExpansionOptions,
   type RoundtripResult,
   type StepConversionFailureClass,
 } from "@galaxy-tool-util/schema";
 import { loadToolInputsForWorkflow } from "../src/commands/stateful-tool-inputs.js";
+import {
+  decodeStructureErrorsJsonSchema,
+  validateFormat2StepsJsonSchema,
+} from "../src/commands/validate-workflow-json-schema.js";
 import { createDefaultResolver } from "../src/commands/url-resolver.js";
 
 const IWC_DIR = process.env.GALAXY_TEST_IWC_DIRECTORY;
@@ -200,3 +206,164 @@ describe.skipIf(!IWC_DIR)("IWC stateful sweep: convert + roundtrip", { timeout: 
     }
   });
 });
+
+// --- Format2 two-level JSON Schema sweep ---
+
+// Export each native IWC workflow to format2, then run two-level JSON Schema
+// validation on the result (structural + per-step tool state). Mirrors Python
+// TestIWCSweepJsonSchema. Uncached tools produce skips (not failures); a
+// structural error or a per-step `fail` is a real regression.
+describe.skipIf(!IWC_DIR)("IWC stateful sweep: format2 JSON Schema", { timeout: 600_000 }, () => {
+  let workflows: string[];
+  let cache: ToolCache;
+
+  beforeAll(async () => {
+    workflows = await discoverNativeWorkflows(join(IWC_DIR!, "workflows"));
+    cache = makeNodeToolCache();
+    await cache.index.load();
+  });
+
+  it("exported format2 passes two-level JSON Schema validation", async () => {
+    const failures: Array<{ workflow: string; errors: string[] }> = [];
+    let structuralOk = 0;
+    let stepsValidated = 0;
+    let stepsSkipped = 0;
+
+    for (const wfPath of workflows) {
+      const id = workflowId(wfPath);
+      let data: Record<string, unknown>;
+      try {
+        data = JSON.parse(await readFile(wfPath, "utf-8"));
+      } catch {
+        continue;
+      }
+
+      const expansionOpts: ExpansionOptions = {
+        resolver: createDefaultResolver({ workflowDirectory: join(wfPath, "..") }),
+      };
+      let fmt2: Record<string, unknown>;
+      try {
+        const { resolver } = await loadToolInputsForWorkflow(data, "native", cache, expansionOpts);
+        fmt2 = toFormat2Stateful(data, resolver).workflow as unknown as Record<string, unknown>;
+      } catch (err) {
+        failures.push({
+          workflow: id,
+          errors: [
+            `export to format2 crashed: ${err instanceof Error ? err.message : String(err)}`,
+          ],
+        });
+        continue;
+      }
+
+      const errors: string[] = [];
+      const structErrors = decodeStructureErrorsJsonSchema(fmt2, "format2");
+      if (structErrors.length > 0) {
+        errors.push(...structErrors.map((e) => `structural: ${e}`));
+      } else {
+        structuralOk++;
+      }
+
+      const stepResults = await validateFormat2StepsJsonSchema(
+        fmt2,
+        cache,
+        undefined,
+        "",
+        expansionOpts,
+      );
+      for (const r of stepResults) {
+        if (SKIP_STATUSES.has(r.status)) stepsSkipped++;
+        else if (r.status === "fail") {
+          errors.push(`step ${r.step} (${r.tool_id}): ${r.errors.join("; ")}`);
+        } else stepsValidated++;
+      }
+
+      if (errors.length > 0) failures.push({ workflow: id, errors });
+    }
+
+    console.log(
+      `\nIWC format2 JSON Schema sweep: ${structuralOk}/${workflows.length} structurally valid`,
+    );
+    console.log(`  steps: ${stepsValidated} validated, ${stepsSkipped} skipped`);
+
+    if (failures.length > 0) {
+      const details = failures
+        .slice(0, 20)
+        .map((f) => `  ${f.workflow}:\n    ${f.errors.slice(0, 5).join("\n    ")}`)
+        .join("\n");
+      const truncated = failures.length > 20 ? `\n  ... and ${failures.length - 20} more` : "";
+      expect.fail(
+        `${failures.length} workflow(s) failed format2 JSON Schema validation:\n${details}${truncated}`,
+      );
+    }
+  });
+});
+
+// --- Roundtrip strict-encoding sweep ---
+
+// Roundtrip each workflow with strict-encoding on, asserting the format2
+// (`forward:`) and reimported-native (`reverse:`) outputs both satisfy
+// strict-encoding (tool_state is a parsed dict, not a per-key JSON string).
+// Mirrors Python TestIWCSweepRoundtripStrictEncoding. `input:` errors are
+// excluded — raw .ga stores tool_state as a JSON string, so strict-encoding is
+// only meaningful on the conversion outputs (which is what Python checks).
+describe.skipIf(!IWC_DIR)(
+  "IWC stateful sweep: roundtrip strict-encoding",
+  { timeout: 600_000 },
+  () => {
+    let workflows: string[];
+    let cache: ToolCache;
+
+    beforeAll(async () => {
+      workflows = await discoverNativeWorkflows(join(IWC_DIR!, "workflows"));
+      cache = makeNodeToolCache();
+      await cache.index.load();
+    });
+
+    it("roundtrip outputs satisfy strict-encoding", async () => {
+      const failures: Array<{ workflow: string; errors: string[] }> = [];
+
+      for (const wfPath of workflows) {
+        const id = workflowId(wfPath);
+        let data: Record<string, unknown>;
+        try {
+          data = JSON.parse(await readFile(wfPath, "utf-8"));
+        } catch {
+          continue;
+        }
+
+        const expansionOpts: ExpansionOptions = {
+          resolver: createDefaultResolver({ workflowDirectory: join(wfPath, "..") }),
+        };
+        try {
+          const { resolver } = await loadToolInputsForWorkflow(
+            data,
+            "native",
+            cache,
+            expansionOpts,
+          );
+          const result = roundtripValidate(data, resolver, { strictEncoding: true });
+          const outputErrors = result.encodingErrors.filter((e) => !e.startsWith("input:"));
+          if (outputErrors.length > 0) {
+            failures.push({ workflow: id, errors: outputErrors });
+          }
+        } catch (err) {
+          failures.push({
+            workflow: id,
+            errors: [`roundtrip crashed: ${err instanceof Error ? err.message : String(err)}`],
+          });
+        }
+      }
+
+      if (failures.length > 0) {
+        const details = failures
+          .slice(0, 20)
+          .map((f) => `  ${f.workflow}:\n    ${f.errors.slice(0, 5).join("\n    ")}`)
+          .join("\n");
+        const truncated = failures.length > 20 ? `\n  ... and ${failures.length - 20} more` : "";
+        expect.fail(
+          `${failures.length} workflow(s) had roundtrip strict-encoding errors:\n${details}${truncated}`,
+        );
+      }
+    });
+  },
+);

--- a/packages/cli/test/stateful-iwc-sweep.test.ts
+++ b/packages/cli/test/stateful-iwc-sweep.test.ts
@@ -50,6 +50,15 @@ function workflowId(path: string): string {
   return relative(`${IWC_DIR}/workflows`, path);
 }
 
+// Workflows with known error-severity roundtrip diffs, excluded so the sweep
+// flags only NEW regressions. Python's reference roundtrip_validate also fails
+// these (not a TS-only issue). Prune as the upstream conversion bugs are fixed.
+const KNOWN_ROUNDTRIP_FAILURES: ReadonlySet<string> = new Set([
+  // jmchilton/galaxy-tool-util-ts#117 — peptideshaker step drop + dbbuilder
+  // `source` conditional mis-selection on the reverse pass.
+  "proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow.ga",
+]);
+
 interface WorkflowOutcome {
   workflow: string;
   crashed: boolean;
@@ -75,8 +84,13 @@ describe.skipIf(!IWC_DIR)("IWC stateful sweep: convert + roundtrip", { timeout: 
     const outcomes: WorkflowOutcome[] = [];
     let parseErrors = 0;
 
+    let knownFailing = 0;
     for (const wfPath of workflows) {
       const id = workflowId(wfPath);
+      if (KNOWN_ROUNDTRIP_FAILURES.has(id)) {
+        knownFailing++;
+        continue;
+      }
       let data: Record<string, unknown>;
       try {
         const raw = await readFile(wfPath, "utf-8");
@@ -148,10 +162,11 @@ describe.skipIf(!IWC_DIR)("IWC stateful sweep: convert + roundtrip", { timeout: 
         for (const d of step.diffs) {
           if (d.severity === "error") {
             totalErrorDiffs++;
-            errorMessages.push(`step ${step.stepId} ${d.path || "<root>"}: ${d.message}`);
+            errorMessages.push(`step ${step.stepId} ${d.key_path || "<root>"}: ${d.description}`);
           } else {
             totalBenignDiffs++;
-            const kind: BenignArtifactKind | "unclassified" = d.kind ?? "unclassified";
+            const kind: BenignArtifactKind | "unclassified" =
+              d.benign_artifact?.reason ?? "unclassified";
             benignKinds[kind] = (benignKinds[kind] ?? 0) + 1;
           }
         }
@@ -176,6 +191,7 @@ describe.skipIf(!IWC_DIR)("IWC stateful sweep: convert + roundtrip", { timeout: 
         .join(", ") || "(none)";
 
     console.log(`\nIWC stateful sweep: ${totalWorkflows} workflows, ${totalSteps} tool steps`);
+    if (knownFailing > 0) console.log(`  known-failing (excluded): ${knownFailing}`);
     if (parseErrors > 0) console.log(`  parse errors: ${parseErrors}`);
     console.log(
       `  verdicts: ${cleanWorkflows} clean, ${benignWorkflows} benign-only, ${errorWorkflows} with real errors, ${crashes.length} crashed`,

--- a/packages/schema/src/workflow/state-merge.ts
+++ b/packages/schema/src/workflow/state-merge.ts
@@ -48,6 +48,22 @@ export function nativeConnectionsFromFormat2In(
 
 // --- Main injection function ---
 
+export interface InjectConnectionsOptions {
+  /**
+   * Target the `workflow_step_linked` representation. A connected `multiple`
+   * select is encoded there as a single-element list `[{ConnectedValue}]` (the
+   * select-multiple linked schema accepts ConnectedValue only as an array item,
+   * per Galaxy's parameter_specification.yml), whereas every other parameter —
+   * and the native representation — uses a bare `{ConnectedValue}`.
+   */
+  linked?: boolean;
+}
+
+function isMultipleSelect(input: ToolParameterModel): boolean {
+  const p = input as { parameter_type?: string; multiple?: boolean };
+  return p.parameter_type === "gx_select" && p.multiple === true;
+}
+
 /**
  * Inject ConnectedValue markers into a state dict for all connections.
  *
@@ -61,16 +77,19 @@ export function injectConnectionsIntoState(
   toolInputs: ToolParameterModel[],
   state: Record<string, unknown>,
   connections: Record<string, unknown>,
+  options?: InjectConnectionsOptions,
 ): Record<string, unknown> {
   const remaining = { ...connections };
   const result = walkNativeState(
     connections,
     toolInputs,
     state,
-    (_input, value, statePath) => {
+    (input, value, statePath) => {
       if (statePath in remaining) {
         delete remaining[statePath];
-        return { ...CONNECTED_VALUE };
+        return options?.linked && isMultipleSelect(input)
+          ? [{ ...CONNECTED_VALUE }]
+          : { ...CONNECTED_VALUE };
       }
       return value === undefined ? SKIP_VALUE : value;
     },


### PR DESCRIPTION
> 🤖 PR opened by Claude (AI assistant) on behalf of @jmchilton.

## Why

A comparison of the TypeScript IWC sweeps against Galaxy's Python `test_iwc_sweep.py` found (a) missing sweep coverage, (b) a real validator bug that rejected valid workflows, and (c) the sweeps never actually ran in CI (they `skipIf(!GALAXY_TEST_IWC_DIRECTORY)`). This closes all three.

## What

**`fix(schema,cli)`: format2 two-level JSON Schema validation parity**
- **Connected multi-selects now validate.** A connected `multiple` select is encoded in `workflow_step_linked` as a single-element list `[{ConnectedValue}]` (the linked select-multiple schema accepts ConnectedValue only as an *array item*, per Galaxy's `parameter_specification.yml`). `injectConnectionsIntoState` gained a `{ linked: true }` option; previously it emitted a bare `{ConnectedValue}` that the schema rejected (`must be array; must be null; anyOf`). This was the root cause of the `metaprosip` / `sylph_database` sweep failures — Galaxy's own validator never hit it because it validates against `workflow_step_native` (where bare ConnectedValue is valid), not linked.
- **No more crash on multi-`unknown` tools.** Each tool schema compiles in its own ajv instance with `$id` stripped, fixing `"/schemas/unknown" resolves to more than one schema`.
- **Non-strict structural + tolerate unmatched connection keys** (e.g. the `when` gate), matching Python's `validate_workflow_json_schema`.

**`test(cli)`: new IWC sweeps** mirroring Python `TestIWCSweep{LintStateful,JsonSchema,RoundtripStrictEncoding}`, plus the `STRICT_STRUCTURE_SKIP` allowlist (4 deprecated-position workflows), kept in sync with `test_iwc_sweep.py`.

**`ci(cli)`: run the sweeps in CI** — new `iwc-sweep` job: checks out `galaxyproject/iwc` at a pinned ref, restores/populates the tool cache (`actions/cache` + `galaxy-tool-cache populate-workflow`, keyed on the IWC ref so PRs reuse it), then runs both sweep files. Also fixes the convert+roundtrip diff display (`key_path`/`description`/`benign_artifact.reason` — was printing `undefined`).

## Known-failing allowlists (flag only NEW regressions)

- `clinicalmp-discovery` roundtrip — tracked in #117 (peptideshaker step drop + dbbuilder conditional mis-selection; Galaxy's reference roundtrip also fails it, not a TS-only issue).
- 4 deprecated-position workflows (`STRICT_STRUCTURE_SKIP`) and the 82 tests-file drift files remain allowlisted as before.

## Notes / caveats

- The TS sweeps don't auto-populate from the ToolShed, so the CI job fetches ~551 unique tools on a **cold** cache (first run, or after bumping `IWC_REF`); `actions/cache` amortizes it thereafter. Tools that fail to fetch degrade to skips rather than failing the job.
- `IWC_REF` is pinned for determinism — bump it together with the three allowlists when the corpus drifts.

## Test plan

- `make check` green; schema **4901** + cli **337** unit tests pass.
- IWC sweeps **14/14 green** locally (`GALAXY_TEST_IWC_DIRECTORY=~/projects/repositories/iwc`), 122 workflows, format2 JSON Schema 122/122 structurally valid.
- Changeset included (`@galaxy-tool-util/schema` + `@galaxy-tool-util/cli`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
