### PR TITLE
fix(schema): quote YAML 1.1 reserved words in format2 emit

### DIFF
--- a/.changeset/emit-yaml11-quoting.md
+++ b/.changeset/emit-yaml11-quoting.md
@@ -1,0 +1,5 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+Emit format2 YAML with the `yaml-1.1` schema so reserved words quote. `serializeWorkflow` previously stringified with the default core (1.2) schema, leaving word-form booleans (`no`/`yes`/`on`/`off`) bare; a YAML 1.1 reader (e.g. Galaxy's PyYAML) then coerced them to booleans, corrupting string tool_state values like a select's `"no"`. Real numbers and booleans are unaffected.

--- a/packages/schema/src/workflow/serialize.ts
+++ b/packages/schema/src/workflow/serialize.ts
@@ -24,6 +24,12 @@ export interface SerializeWorkflowOptions {
  * `json` / `yaml` overrides).
  *
  * YAML uses `lineWidth: 0` to disable line-wrapping so diffs stay stable.
+ *
+ * The `yaml-1.1` schema is used for emission so the writer quotes plain scalars
+ * that a YAML 1.1 reader (e.g. PyYAML, which Galaxy uses) would otherwise coerce
+ * — the word-form booleans `no`/`yes`/`on`/`off`/`y`/`n`. Tool_state stores these
+ * as strings (a select option value like `"no"`); emitting them bare lets a 1.1
+ * reader decode them as booleans. Real numbers/booleans are unaffected.
  */
 export function serializeWorkflow(
   data: Record<string, unknown>,
@@ -33,7 +39,7 @@ export function serializeWorkflow(
   const useYaml = opts.yaml || (!opts.json && format === "format2");
   const newline = opts.trailingNewline ?? true;
   if (useYaml) {
-    const out = stringifyYaml(data, { lineWidth: 0 });
+    const out = stringifyYaml(data, { lineWidth: 0, schema: "yaml-1.1" });
     // `yaml` already ends with a newline; don't double-append.
     if (newline) return out.endsWith("\n") ? out : out + "\n";
     return out.endsWith("\n") ? out.slice(0, -1) : out;

--- a/packages/schema/test/serialize.test.ts
+++ b/packages/schema/test/serialize.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeWorkflow } from "../src/workflow/serialize.js";
+
+describe("serializeWorkflow format2 YAML", () => {
+  it("quotes YAML 1.1 word-form booleans so 1.1 readers keep them as strings", () => {
+    const out = serializeWorkflow(
+      { steps: { s: { tool_state: { guide: { use_guide: "no", also: "yes", flag: "on" } } } } },
+      "format2",
+    );
+    expect(out).toContain('use_guide: "no"');
+    expect(out).toContain('also: "yes"');
+    expect(out).toContain('flag: "on"');
+  });
+
+  it("leaves real booleans and numbers unquoted", () => {
+    const out = serializeWorkflow({ enabled: true, count: 5, ratio: 1.5 }, "format2");
+    expect(out).toContain("enabled: true");
+    expect(out).toContain("count: 5");
+    expect(out).toContain("ratio: 1.5");
+  });
+
+  it("quotes numeric-looking strings", () => {
+    const out = serializeWorkflow({ fraction: "0.01" }, "format2");
+    expect(out).toContain('fraction: "0.01"');
+  });
+
+  it("leaves ordinary strings unquoted", () => {
+    const out = serializeWorkflow({ label: "hello" }, "format2");
+    expect(out).toContain("label: hello");
+  });
+});


### PR DESCRIPTION
> 🤖 Opened by Claude (AI assistant) on jmchilton's behalf — not personally authored.

## Problem

`serializeWorkflow` stringified format2 YAML with the `yaml` lib's default **core (1.2)** schema, which leaves the word-form booleans `no`/`yes`/`on`/`off`/`y`/`n` **unquoted**. Galaxy reads format2 with a YAML **1.1** loader (PyYAML), which coerces those bare scalars to booleans — so a string tool_state value like a select's `"no"` (e.g. StringTie `use_guide`) becomes `False` on the Galaxy side and fails the conditional discriminator.

## Fix

Stringify with `schema: "yaml-1.1"`, so the writer quotes exactly the scalars a 1.1 reader would misinterpret. Real numbers and booleans are unaffected; numeric-looking strings were already quoted.

```
use_guide: "no"     # was: use_guide: no
enabled: true       # unchanged
count: 5            # unchanged
fraction: "0.01"    # already quoted
label: hello        # unchanged
```

Verified the output round-trips correctly through a plain (unmodified) PyYAML 1.1 reader.

## Tests

New `packages/schema/test/serialize.test.ts` (4 tests) covering word-bool quoting, numeric-string quoting, and that real bools/numbers/plain strings stay bare. Schema suite green (4901 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)