### PR TITLE
fix(schema): deduplicate galaxyWorkflowDraftJsonSchema via $defs/$ref

### DIFF
--- a/.changeset/dedupe-draft-json-schema.md
+++ b/.changeset/dedupe-draft-json-schema.md
@@ -1,0 +1,16 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+fix: deduplicate `galaxyWorkflowDraftJsonSchema` via `$defs`/`$ref`
+
+`JSONSchema.make` inlines every subschema lacking an `identifier` annotation, so
+structurally-identical fragments (workflow step variants, tool_state value types,
+RuntimeValue/ConnectedValue, …) were duplicated many times over — inflating the plain-JSON
+draft schema to ~95 KB compact / ~580 KB pretty-printed. A schema-aware post-process now
+hoists each repeated subschema into `$defs` and replaces its occurrences with `$ref`,
+operating only at legal schema positions (`properties` values, `items`, `anyOf` members, …)
+and never on array/value keywords like `required`/`enum`/`type`. The result is ~19 KB
+compact / ~60 KB pretty-printed with identical validation behavior (still compiles under
+Ajv 2020-12; accepts/rejects the same documents), so downstream packagers that vendor the
+schema verbatim no longer ship a ~580 KB file per bundle.

--- a/packages/schema/src/workflow/json-schemas.ts
+++ b/packages/schema/src/workflow/json-schemas.ts
@@ -31,9 +31,142 @@ function stripDuplicateUnknownIds(node: unknown): void {
   for (const k of Object.keys(obj)) stripDuplicateUnknownIds(obj[k]);
 }
 
+/**
+ * `JSONSchema.make` inlines every subschema lacking an `identifier`
+ * annotation, so structurally-identical fragments (workflow step variants,
+ * tool_state value types, RuntimeValue/ConnectedValue, …) are duplicated many
+ * times over. The draft schema reaches ~95 KB compact and ~580 KB
+ * pretty-printed (deep nesting amplifies indentation), which is impractical
+ * for downstream packagers to vendor verbatim. Hoist each repeated subschema
+ * into `$defs` and replace its occurrences with `$ref`, shrinking the document
+ * with no change in meaning.
+ *
+ * Replacement happens **only at schema positions** — a `$ref` is legal where a
+ * subschema is expected (`properties` values, `items`, `anyOf` members, …) but
+ * not in array/value keywords like `required`, `enum`, or `type`. Output is
+ * deterministic (candidates chosen by largest byte saving, ties broken by
+ * canonical form; `$def` names assigned in hoist order) so the generated
+ * schema is byte-stable across runs.
+ */
+const SCHEMA_OBJ_KEYS = [
+  "additionalProperties",
+  "items",
+  "additionalItems",
+  "contains",
+  "propertyNames",
+  "not",
+  "if",
+  "then",
+  "else",
+  "unevaluatedProperties",
+  "unevaluatedItems",
+];
+const SCHEMA_MAP_KEYS = [
+  "properties",
+  "patternProperties",
+  "dependentSchemas",
+  "$defs",
+  "definitions",
+];
+const SCHEMA_ARR_KEYS = ["allOf", "anyOf", "oneOf", "prefixItems"];
+
+const isPlainObject = (n: unknown): n is Record<string, unknown> =>
+  n !== null && typeof n === "object" && !Array.isArray(n);
+
+/** Stable serialization (sorted object keys) for structural equality. */
+function canonicalize(node: unknown): string {
+  if (!isPlainObject(node)) {
+    if (Array.isArray(node)) return `[${node.map(canonicalize).join(",")}]`;
+    return JSON.stringify(node) ?? "null";
+  }
+  return `{${Object.keys(node)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${canonicalize(node[k])}`)
+    .join(",")}}`;
+}
+
+type SchemaVisitor = (node: unknown, replace: (next: unknown) => void, isRoot: boolean) => void;
+
+/** Walk every node that sits in a JSON-Schema position; `replace` swaps it in its parent. */
+function eachSchemaNode(
+  node: unknown,
+  replace: (next: unknown) => void,
+  visit: SchemaVisitor,
+  isRoot = true,
+): void {
+  visit(node, replace, isRoot);
+  if (!isPlainObject(node)) return;
+  for (const k of SCHEMA_OBJ_KEYS) {
+    if (isPlainObject(node[k])) eachSchemaNode(node[k], (v) => (node[k] = v), visit, false);
+  }
+  for (const k of SCHEMA_MAP_KEYS) {
+    const map = node[k];
+    if (isPlainObject(map)) {
+      for (const sk of Object.keys(map))
+        eachSchemaNode(map[sk], (v) => (map[sk] = v), visit, false);
+    }
+  }
+  for (const k of SCHEMA_ARR_KEYS) {
+    const arr = node[k];
+    if (Array.isArray(arr)) {
+      for (let i = 0; i < arr.length; i++)
+        eachSchemaNode(arr[i], (v) => (arr[i] = v), visit, false);
+    }
+  }
+}
+
+function dedupeSubschemas(root: Record<string, unknown>): void {
+  const MIN_BYTES = 200;
+  const defs = (root.$defs && isPlainObject(root.$defs) ? root.$defs : (root.$defs = {})) as Record<
+    string,
+    unknown
+  >;
+  let counter = 0;
+  for (let guard = 0; guard < 5000; guard++) {
+    const tally = new Map<string, { count: number; size: number }>();
+    eachSchemaNode(
+      root,
+      () => {},
+      (node, _replace, isRoot) => {
+        if (isRoot || !isPlainObject(node)) return;
+        const s = canonicalize(node);
+        if (s.length < MIN_BYTES) return;
+        const cur = tally.get(s);
+        if (cur) cur.count++;
+        else tally.set(s, { count: 1, size: s.length });
+      },
+    );
+
+    let best: string | null = null;
+    let bestSaving = 0;
+    for (const [s, { count, size }] of tally) {
+      if (count < 2) continue;
+      const saving = (count - 1) * size;
+      if (saving > bestSaving || (saving === bestSaving && (best === null || s < best))) {
+        bestSaving = saving;
+        best = s;
+      }
+    }
+    if (best === null) break;
+
+    const name = `Shared${counter++}`;
+    const ref = `#/$defs/${name}`;
+    eachSchemaNode(
+      root,
+      () => {},
+      (node, replace, isRoot) => {
+        if (isRoot || !isPlainObject(node)) return;
+        if (canonicalize(node) === best) replace({ $ref: ref });
+      },
+    );
+    defs[name] = JSON.parse(best);
+  }
+}
+
 const draftJsonSchema = JSONSchema.make(GalaxyWorkflowDraftSchema, {
   target: "jsonSchema2020-12",
-}) as object;
+}) as unknown as Record<string, unknown>;
 stripDuplicateUnknownIds(draftJsonSchema);
+dedupeSubschemas(draftJsonSchema);
 
 export const galaxyWorkflowDraftJsonSchema = draftJsonSchema;

--- a/packages/schema/test/workflow-json-schemas.test.ts
+++ b/packages/schema/test/workflow-json-schemas.test.ts
@@ -62,4 +62,32 @@ describe("galaxyWorkflowDraftJsonSchema", () => {
     const bad = { class: "NotADraft", steps: [] };
     expect(validate(bad)).toBe(false);
   });
+
+  it("hoists repeated subschemas into $defs with only resolvable $refs", () => {
+    const schema = galaxyWorkflowDraftJsonSchema as Record<string, unknown>;
+    const defs = (schema.$defs ?? {}) as Record<string, unknown>;
+    const names = new Set(Object.keys(defs));
+    expect(names.size).toBeGreaterThan(0);
+    let refs = 0;
+    const walk = (n: unknown): void => {
+      if (!n || typeof n !== "object") return;
+      const ref = (n as Record<string, unknown>).$ref;
+      if (typeof ref === "string") {
+        refs++;
+        const m = ref.match(/^#\/\$defs\/(.+)$/);
+        expect(m, `unexpected $ref form: ${ref}`).not.toBeNull();
+        expect(names.has(m![1]), `dangling $ref: ${ref}`).toBe(true);
+      }
+      for (const v of Object.values(n as Record<string, unknown>)) walk(v);
+    };
+    walk(schema);
+    expect(refs).toBeGreaterThan(0);
+  });
+
+  it("stays compact so downstream packagers can vendor it verbatim", () => {
+    // Pre-dedup the inlined draft schema was ~580 KB pretty-printed; the $ref
+    // dedup brings it to well under 100 KB. Guard against re-bloat regressions.
+    const pretty = JSON.stringify(galaxyWorkflowDraftJsonSchema, null, 2).length;
+    expect(pretty).toBeLessThan(200_000);
+  });
 });


### PR DESCRIPTION
> Opened by Claude (AI assistant) on jmchilton's behalf.

## Problem

`galaxyWorkflowDraftJsonSchema` (the plain-JSON sibling of the Effect `GalaxyWorkflowDraftSchema`, added in 1.7.x) is **~95 KB compact / ~580 KB pretty-printed**. `JSONSchema.make` inlines every subschema that lacks an `identifier` annotation, so structurally-identical fragments — workflow step variants, `tool_state` value types, `RuntimeValue`/`ConnectedValue`, free-form `state`/`default`, … — are duplicated many times over, and deep nesting amplifies indentation in the pretty-printed form.

This breaks downstream packagers that vendor the schema verbatim. In the Galaxy Workflow Foundry, casting bundles the schema into every producer skill (`JSON.stringify(schema, null, 2)`); five 569 KB copies tripped the repo's `check-added-large-files` guard.

The source `gxformat2-draft.effect.ts` is generated (`schema-salad-plus-pydantic`, "do not edit"), so the fix is a post-process — alongside the existing `stripDuplicateUnknownIds`.

## Fix

A schema-aware deduplicator hoists each repeated subschema into `$defs` and replaces its occurrences with `$ref`. It walks **only legal schema positions** (`properties`/`patternProperties`/`$defs` values, `items`/`additionalProperties`/`contains`/`if`/`then`/`else`, `allOf`/`anyOf`/`oneOf`/`prefixItems` members) and never touches array/value keywords like `required`, `enum`, or `type` — so every emitted `$ref` sits where a subschema is valid. Output is deterministic (candidates chosen by largest byte saving, ties broken by canonical form; `$def` names assigned in hoist order), so the generated schema is byte-stable across runs.

**Result:** ~19 KB compact / ~60 KB pretty-printed (19 `$defs`, 42 resolvable `$ref`s) with identical validation behavior.

## Tests

`packages/schema/test/workflow-json-schemas.test.ts` adds:
- every `$ref` resolves to an existing `$defs` entry (no dangling refs);
- pretty-printed size stays under 200 KB (re-bloat guard).

Existing assertions unchanged: still serializes, compiles under Ajv 2020-12, accepts the known-good fixture, rejects the malformed one. Full schema suite: 4913 pass. `tsc`, eslint, prettier clean.

Patch bump via changeset (packages are linked).
