### PR TITLE
fix(draft-validate): bucket output-source sentinels separately from step paths

### DIFF
--- a/.changeset/draft-survey-output-path-bucket.md
+++ b/.changeset/draft-survey-output-path-bucket.md
@@ -1,0 +1,14 @@
+---
+"@galaxy-tool-util/schema": patch
+"@galaxy-tool-util/cli": patch
+---
+
+fix(draft-validate): stop counting output-source sentinels as step paths
+
+`buildDraftSurveyReport` deduped every TODO sentinel by step path, so
+workflow-output `outputSource` sentinels — all carrying the workflow-root
+path `[]` — collapsed into a single empty bucket and were surfaced as one
+extra "step path" (off-by-one). Output sentinels now get their own
+`DraftSurveyReport.todo_output_paths` bucket, keyed by `[...path, outputLabel]`,
+and the `gxwf draft-validate` survey line / report template report them as
+"N step path(s) and M output path(s)".

--- a/packages/cli/src/commands/draft-validate.ts
+++ b/packages/cli/src/commands/draft-validate.ts
@@ -265,7 +265,8 @@ function printTextReport(report: SingleDraftValidationReport, result: DraftValid
   const survey = report.survey;
   console.log(
     `  Survey: ${survey.todo_count} TODO sentinel${survey.todo_count === 1 ? "" : "s"}` +
-      ` across ${survey.todo_paths.length} step path${survey.todo_paths.length === 1 ? "" : "s"};` +
+      ` across ${survey.todo_paths.length} step path${survey.todo_paths.length === 1 ? "" : "s"}` +
+      ` and ${survey.todo_output_paths.length} output path${survey.todo_output_paths.length === 1 ? "" : "s"};` +
       ` ${survey.plan_step_paths.length} step${survey.plan_step_paths.length === 1 ? "" : "s"} with _plan_* fields`,
   );
   if (report.concrete) printConcrete(report.concrete);

--- a/packages/cli/src/workflow/_templates-bundled.ts
+++ b/packages/cli/src/workflow/_templates-bundled.ts
@@ -160,7 +160,7 @@ Summary: {{ report.summary }}
 ## Survey
 
 - Draft: {% if report.survey.is_draft %}yes{% else %}no{% endif %}
-- TODO sentinels: {{ report.survey.todo_count }} across {{ report.survey.todo_paths | length }} step path(s)
+- TODO sentinels: {{ report.survey.todo_count }} across {{ report.survey.todo_paths | length }} step path(s) and {{ report.survey.todo_output_paths | length }} output path(s)
 - Steps with \`_plan_*\` fields: {{ report.survey.plan_step_paths | length }}
 
 {% if report.structure_errors | length > 0 %}

--- a/packages/cli/src/workflow/templates/reports/draft_validate.md.j2
+++ b/packages/cli/src/workflow/templates/reports/draft_validate.md.j2
@@ -14,7 +14,7 @@ Summary: {{ report.summary }}
 ## Survey
 
 - Draft: {% if report.survey.is_draft %}yes{% else %}no{% endif %}
-- TODO sentinels: {{ report.survey.todo_count }} across {{ report.survey.todo_paths | length }} step path(s)
+- TODO sentinels: {{ report.survey.todo_count }} across {{ report.survey.todo_paths | length }} step path(s) and {{ report.survey.todo_output_paths | length }} output path(s)
 - Steps with `_plan_*` fields: {{ report.survey.plan_step_paths | length }}
 
 {% if report.structure_errors | length > 0 %}

--- a/packages/cli/test/draft-validate.test.ts
+++ b/packages/cli/test/draft-validate.test.ts
@@ -41,9 +41,10 @@ describe("draft-validate (text mode)", () => {
     expect(out).not.toContain("Structure errors");
     expect(out).not.toContain("Topology errors");
     expect(out).not.toContain("Semantic errors");
-    // Survey line: plural sentinels + paths (fixture has 6 across 2), singular step with _plan_*.
+    // Survey line: 6 sentinels — 5 on the single step path, 1 on the single
+    // output path (fixture's outputSource port). Singular step with _plan_*.
     expect(out).toMatch(
-      /Survey: 6 TODO sentinels across 2 step paths; 1 step with _plan_\* fields/,
+      /Survey: 6 TODO sentinels across 1 step path and 1 output path; 1 step with _plan_\* fields/,
     );
     expect(process.exitCode).toBe(0);
   });
@@ -68,7 +69,7 @@ steps:
     await runDraftValidate(wfPath, {});
     const out = joined(ctx.logSpy);
     expect(out).toMatch(
-      /Survey: 0 TODO sentinels across 0 step paths; 0 steps with _plan_\* fields/,
+      /Survey: 0 TODO sentinels across 0 step paths and 0 output paths; 0 steps with _plan_\* fields/,
     );
   });
 

--- a/packages/schema/src/workflow/report-models.ts
+++ b/packages/schema/src/workflow/report-models.ts
@@ -157,6 +157,13 @@ export interface DraftSurveyReport {
   todo_count: number;
   /** Distinct step paths carrying at least one TODO sentinel, in walk order. */
   todo_paths: string[][];
+  /**
+   * Distinct workflow-output locations carrying a TODO sentinel in their
+   * `outputSource`, in walk order. Each entry is `[...workflowPath, outputLabel]`
+   * — `["trimmed"]` for a root output, `["sub", "trimmed"]` for a subworkflow
+   * output. Kept separate from `todo_paths`: an output sentinel is not a step.
+   */
+  todo_output_paths: string[][];
   /** Distinct step paths carrying at least one `_plan_*` field, in walk order. */
   plan_step_paths: string[][];
 }
@@ -715,7 +722,17 @@ export function buildSingleDraftExtractReport(
 function buildDraftSurveyReport(survey: DraftSurvey): DraftSurveyReport {
   const todoSeen = new Set<string>();
   const todoPaths: string[][] = [];
+  const outputSeen = new Set<string>();
+  const todoOutputPaths: string[][] = [];
   for (const hit of survey.todos) {
+    if (hit.location.kind === "output_source") {
+      const outputPath = [...hit.path, hit.location.output_label];
+      const key = outputPath.join("/");
+      if (outputSeen.has(key)) continue;
+      outputSeen.add(key);
+      todoOutputPaths.push(outputPath);
+      continue;
+    }
     const key = hit.path.join("/");
     if (todoSeen.has(key)) continue;
     todoSeen.add(key);
@@ -733,6 +750,7 @@ function buildDraftSurveyReport(survey: DraftSurvey): DraftSurveyReport {
     is_draft: survey.isDraft,
     todo_count: survey.todos.length,
     todo_paths: todoPaths,
+    todo_output_paths: todoOutputPaths,
     plan_step_paths: planStepPaths,
   };
 }

--- a/packages/schema/test/report-models-draft.test.ts
+++ b/packages/schema/test/report-models-draft.test.ts
@@ -36,6 +36,7 @@ describe("buildSingleDraftValidationReport", () => {
       is_draft: true,
       todo_count: 0,
       todo_paths: [],
+      todo_output_paths: [],
       plan_step_paths: [],
     });
   });
@@ -79,8 +80,35 @@ describe("buildSingleDraftValidationReport", () => {
     };
     const r = buildSingleDraftValidationReport("dedup.gxwf.yml", validateDraft(wf));
     expect(r.survey.todo_paths).toEqual([["fastp"], ["chain"]]);
+    expect(r.survey.todo_output_paths).toEqual([]);
     expect(r.survey.plan_step_paths).toEqual([["fastp"]]);
     expect(r.survey.todo_count).toBeGreaterThan(2);
+  });
+
+  it("buckets output-source sentinels separately from step paths (issue #126)", () => {
+    // 1 tool step + 2 outputs whose outputSource ports are TODO sentinels.
+    // Output sentinels live at the workflow root (path []); they must NOT be
+    // counted as step paths, and must surface as distinct output paths keyed
+    // by output label — not collapsed into a single empty `[]` bucket.
+    const wf = {
+      class: DRAFT_CLASS,
+      inputs: { reads: { type: "data" } },
+      outputs: {
+        trimmed: { outputSource: "fastp/TODO_trimmed" },
+        report: { outputSource: "fastp/TODO_report" },
+      },
+      steps: {
+        fastp: {
+          tool_id: "TODO",
+          tool_version: "TODO",
+          in: { input1: "reads" },
+          out: [{ id: "TODO_trimmed" }, { id: "TODO_report" }],
+        },
+      },
+    };
+    const r = buildSingleDraftValidationReport("outputs.gxwf.yml", validateDraft(wf));
+    expect(r.survey.todo_paths).toEqual([["fastp"]]);
+    expect(r.survey.todo_output_paths).toEqual([["trimmed"], ["report"]]);
   });
 
   it("summarizes warnings without errors as 'draft valid (N warnings)'", () => {


### PR DESCRIPTION
Closes #126.

## Problem

`gxwf draft-validate`'s survey line had an off-by-one: it counted workflow-output `outputSource` TODO sentinels as "step paths." `buildDraftSurveyReport` deduped every sentinel by step path, but output sentinels all carry the workflow-root path `[]`, so they collapsed into a single empty bucket that was surfaced as one extra "step path."

A draft with 14 tool steps + 7 outputs (all sentinels) printed `... across 15 step paths` — 14 real step paths + 1 collapsed empty output bucket.

## Fix

- **`packages/schema/src/workflow/report-models.ts`** — `buildDraftSurveyReport` now partitions `survey.todos` on `location.kind === "output_source"`. Output sentinels populate a new `DraftSurveyReport.todo_output_paths`, keyed by `[...path, outputLabel]` (so root output `trimmed` → `["trimmed"]`, never an empty `[]`). `todo_paths` is now strictly step paths.
- **`packages/cli/src/commands/draft-validate.ts`** + **`draft_validate.md.j2`** (rebundled, not hand-edited) — survey wording is now `N step path(s) and M output path(s)`.
- **Tests** — updated survey assertions in `report-models-draft.test.ts` and `draft-validate.test.ts`; added a regression test that a 1-step + 2-output fixture yields `todo_paths: [["fastp"]]` and `todo_output_paths: [["trimmed"], ["report"]]`.

## Verification

Before → after on the issue repro (14 steps, 7 outputs):

```
- Survey: 63 TODO sentinels across 15 step paths; ...
+ Survey: 63 TODO sentinels across 14 step paths and 7 output paths; ...
```

`make check` and `make test` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)