### PR TITLE
fix(populate-workflow): keep caching after an unresolvable tool

### DIFF
--- a/.changeset/populate-workflow-resilient.md
+++ b/.changeset/populate-workflow-resilient.md
@@ -1,0 +1,19 @@
+---
+"@galaxy-tool-util/core": patch
+"@galaxy-tool-util/cli": patch
+---
+
+fix(populate-workflow): don't abort the batch on the first unresolvable tool
+
+`ToolInfoService.getToolInfo` threw `No version available for tool: …` when a
+tool's version couldn't be resolved (short/unversioned ids, local tools, TRS
+errors), violating its `Promise<ParsedTool | null>` contract. The uncaught
+throw escaped `populate-workflow`'s per-tool loop, aborting the whole run and
+caching nothing — even tools already processed.
+
+`getToolInfo` now returns `null` on an unresolvable version, matching the
+existing all-sources-failed path and its declared contract (this also fixes
+`add` and the proxy `getTool`/`toolSchema` routes, which already handled
+`null`). `populate-workflow` additionally wraps each lookup in try/catch so any
+unexpected error downgrades to a per-tool failure and the batch still reports
+`N/M cached, K failed`.

--- a/.changeset/populate-workflow-resilient.md
+++ b/.changeset/populate-workflow-resilient.md
@@ -12,8 +12,8 @@ throw escaped `populate-workflow`'s per-tool loop, aborting the whole run and
 caching nothing — even tools already processed.
 
 `getToolInfo` now returns `null` on an unresolvable version, matching the
-existing all-sources-failed path and its declared contract (this also fixes
-`add` and the proxy `getTool`/`toolSchema` routes, which already handled
-`null`). `populate-workflow` additionally wraps each lookup in try/catch so any
-unexpected error downgrades to a per-tool failure and the batch still reports
-`N/M cached, K failed`.
+existing all-sources-failed path and its declared contract. Every helper it
+calls already swallows its own errors and returns `null`, so the
+`populate-workflow` loop counts the failure and keeps caching the rest,
+reporting `N/M cached, K failed`. This also fixes `add` and the proxy
+`getTool`/`toolSchema` routes, which already handled `null`.

--- a/packages/cli/src/commands/populate-workflow.ts
+++ b/packages/cli/src/commands/populate-workflow.ts
@@ -56,19 +56,13 @@ export async function runPopulateWorkflow(
 
   for (const ref of tools) {
     const label = `${ref.tool_id} v${ref.tool_version ?? "latest"}`;
-    try {
-      const result = await service.getToolInfo(ref.tool_id, ref.tool_version);
-      if (result) {
-        cached++;
-        console.log(`  Cached: ${label}`);
-      } else {
-        failed++;
-        console.warn(`  Failed: ${label}`);
-      }
-    } catch (err) {
+    const result = await service.getToolInfo(ref.tool_id, ref.tool_version);
+    if (result) {
+      cached++;
+      console.log(`  Cached: ${label}`);
+    } else {
       failed++;
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`  Failed: ${label} — ${msg}`);
+      console.warn(`  Failed: ${label}`);
     }
   }
 

--- a/packages/cli/src/commands/populate-workflow.ts
+++ b/packages/cli/src/commands/populate-workflow.ts
@@ -55,13 +55,20 @@ export async function runPopulateWorkflow(
   const total = tools.size;
 
   for (const ref of tools) {
-    const result = await service.getToolInfo(ref.tool_id, ref.tool_version);
-    if (result) {
-      cached++;
-      console.log(`  Cached: ${ref.tool_id} v${ref.tool_version ?? "latest"}`);
-    } else {
+    const label = `${ref.tool_id} v${ref.tool_version ?? "latest"}`;
+    try {
+      const result = await service.getToolInfo(ref.tool_id, ref.tool_version);
+      if (result) {
+        cached++;
+        console.log(`  Cached: ${label}`);
+      } else {
+        failed++;
+        console.warn(`  Failed: ${label}`);
+      }
+    } catch (err) {
       failed++;
-      console.warn(`  Failed: ${ref.tool_id} v${ref.tool_version ?? "latest"}`);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`  Failed: ${label} — ${msg}`);
     }
   }
 

--- a/packages/cli/test/populate-workflow.test.ts
+++ b/packages/cli/test/populate-workflow.test.ts
@@ -82,6 +82,55 @@ describe("galaxy-tool-cache populate-workflow", () => {
     expect(output).toContain("1/1");
   });
 
+  it("keeps caching after an unresolvable tool instead of aborting (issue #127)", async () => {
+    // Mix a pre-cached resolvable tool with a short/unversioned tool whose
+    // latest-version lookup can't resolve. The unresolvable one must not abort
+    // the batch — the resolvable tool still gets cached.
+    await seedSimpleTool(ctx.tmpDir);
+    const workflow = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      steps: {
+        "0": {
+          id: 0,
+          type: "tool",
+          tool_id: "ucsc_axtomaf", // short, unversioned → no TRS entry
+          tool_version: null,
+          tool_state: "{}",
+          input_connections: {},
+        },
+        "1": {
+          id: 1,
+          type: "tool",
+          tool_id: SIMPLE_TOOL_ID,
+          tool_version: "1.0",
+          tool_state: "{}",
+          input_connections: {},
+        },
+      },
+    };
+    const wfPath = join(ctx.tmpDir, "mixed.ga");
+    await writeFile(wfPath, JSON.stringify(workflow));
+
+    // TRS latest-version lookup fails (500) → version cannot resolve.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("Internal Server Error", { status: 500 })) as typeof fetch;
+    try {
+      await runPopulateWorkflow(wfPath, { cacheDir: ctx.tmpDir });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const output = ctx.logSpy.mock.calls.map((c) => c[0]).join("\n");
+    const warnings = ctx.warnSpy.mock.calls.map((c) => c[0]).join("\n");
+    // Resolvable tool still cached despite the earlier failure.
+    expect(output).toContain(`Cached: ${SIMPLE_TOOL_ID}`);
+    expect(output).toContain("1/2");
+    expect(warnings).toContain("Failed: ucsc_axtomaf");
+    expect(process.exitCode).toBe(1);
+  });
+
   it("reports failures for uncached tools", async () => {
     const workflow = {
       a_galaxy_workflow: "true",

--- a/packages/core/src/tool-info.ts
+++ b/packages/core/src/tool-info.ts
@@ -60,7 +60,8 @@ export class ToolInfoService {
     if (resolvedVersion === null) {
       resolvedVersion = await this.resolveLatestVersion(coords.toolshedUrl, coords.trsToolId);
       if (resolvedVersion === null) {
-        throw new Error(`No version available for tool: ${toolId}`);
+        console.debug(`No version available for tool: ${toolId}`);
+        return null;
       }
     }
     const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, resolvedVersion);

--- a/packages/core/test/tool-info.test.ts
+++ b/packages/core/test/tool-info.test.ts
@@ -129,14 +129,13 @@ describe("ToolInfoService", () => {
     expect(fetchCount).toBe(0);
   });
 
-  it("throws when no version is available and TRS returns none", async () => {
+  it("returns null when no version is available and TRS returns none", async () => {
     const service = makeNodeToolInfoService({
       cacheDir: tmpDir,
       fetcher: mockFetch([]),
     });
-    await expect(
-      service.getToolInfo("toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc"),
-    ).rejects.toThrow("No version");
+    const result = await service.getToolInfo("toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc");
+    expect(result).toBeNull();
   });
 
   it("resolves the latest TRS version when the caller omits one", async () => {


### PR DESCRIPTION
Closes #127.

## Problem

`galaxy-tool-cache populate-workflow` threw an **uncaught exception** the moment it hit a tool whose version couldn't be resolved (short/unversioned ids, local tools, or a TRS lookup error). The whole batch died and **nothing** was cached — even tools already processed earlier in the list.

Root cause: `ToolInfoService.getToolInfo` is declared `Promise<ParsedTool | null>` and its all-sources-failed path already returns `null`, but the version-resolution path **threw** `No version available for tool: …` — the one inconsistent exit.

## Fix

- **`packages/core/src/tool-info.ts`** — `getToolInfo` now returns `null` on an unresolvable version, matching its declared contract and the existing all-sources-failed precedent. Since every helper it calls (`resolveLatestVersion`, `loadCached`, the per-source fetch loop) already swallows its own errors and returns `null`, the `populate-workflow` loop simply counts the failure and keeps caching the rest. This also fixes `add` and the proxy `getTool`/`toolSchema` routes, which already handled `null` (and would otherwise have crashed / 500'd on the same input).

> Note: an earlier revision also wrapped the loop in try/catch as defense-in-depth. A code-quality pass showed the contract fix leaves no reachable throw path, so that branch was dropped to keep the loop at a clean two outcomes.

## Tests

- `core/test/tool-info.test.ts` — the "no version available" case now asserts a `null` return instead of a throw (intentional contract change).
- `cli/test/populate-workflow.test.ts` — new regression: a workflow mixing a pre-cached tool with an unversioned/unresolvable one (`ucsc_axtomaf`, TRS 500). Verifies the resolvable tool still caches, the unresolvable one is counted as failed, and the run doesn't abort.

**Red-to-green verified:** against unfixed source the new test fails with `Error: No version available for tool: ucsc_axtomaf`; with the fix it passes. `make check` and `make test` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)