### PR TITLE
fix(cache): default unversioned built-in tools to _default_ sentinel (closes #128)

### DIFF
--- a/.changeset/builtin-tool-default-version.md
+++ b/.changeset/builtin-tool-default-version.md
@@ -1,0 +1,18 @@
+---
+"@galaxy-tool-util/core": patch
+"@galaxy-tool-util/cli": patch
+---
+
+fix(cache): default unversioned stock/built-in tools to the `_default_` sentinel
+
+`resolveToolCoordinates` returned `version: null` for non-ToolShed tool ids
+(stock tools like `cat1`/`Cut1` and built-in collection ops like
+`__APPLY_RULES__`/`__CROSS_PRODUCT_FLAT__`) that carry no explicit version. That
+null short-circuited resolution, so these steps were reported as "no version
+for …" and skipped — even though the json-schema validation path already used
+the `_default_` convention, leaving the resolver internally inconsistent.
+
+The stock-tool branch now mirrors the Python reference
+(`ToolShedGetToolInfo._resolve_tool_coordinates`) and defaults the version to
+`_default_`, so a cache key / schema-cache entry can be formed and the tool
+resolves through the normal cache/fetch path instead of being skipped. Closes #128.

--- a/packages/core/src/cache/tool-cache-defaults.ts
+++ b/packages/core/src/cache/tool-cache-defaults.ts
@@ -4,3 +4,9 @@ export const DEFAULT_TOOLSHED_URL = "https://toolshed.g2.bx.psu.edu";
 export const TOOLSHED_URL_ENV_VAR = "GALAXY_TOOLSHED_URL";
 /** Environment variable to override the cache directory. */
 export const CACHE_DIR_ENV_VAR = "GALAXY_TOOL_CACHE_DIR";
+/**
+ * Sentinel version for stock/built-in Galaxy tools (`cat1`, `__APPLY_RULES__`, …)
+ * that carry no explicit version. Mirrors the Python `_default_` convention so a
+ * cache key / schema-cache entry can still be formed instead of skipping the tool.
+ */
+export const DEFAULT_TOOL_VERSION = "_default_";

--- a/packages/core/src/cache/tool-cache.ts
+++ b/packages/core/src/cache/tool-cache.ts
@@ -5,9 +5,13 @@ import { CacheIndex } from "./cache-index.js";
 import { cacheKey } from "./cache-key.js";
 import { normalizeShortTrsToolId, parseToolshedToolId, toolIdFromTrs } from "./tool-id.js";
 import type { CacheStorage } from "./storage/interface.js";
-import { DEFAULT_TOOLSHED_URL, TOOLSHED_URL_ENV_VAR } from "./tool-cache-defaults.js";
+import {
+  DEFAULT_TOOL_VERSION,
+  DEFAULT_TOOLSHED_URL,
+  TOOLSHED_URL_ENV_VAR,
+} from "./tool-cache-defaults.js";
 
-export { DEFAULT_TOOLSHED_URL, TOOLSHED_URL_ENV_VAR };
+export { DEFAULT_TOOL_VERSION, DEFAULT_TOOLSHED_URL, TOOLSHED_URL_ENV_VAR };
 
 function envToolshedUrl(): string | undefined {
   if (typeof process !== "undefined" && process.env) {
@@ -68,7 +72,7 @@ export class ToolCache {
     return {
       toolshedUrl: this.defaultToolshedUrl,
       trsToolId,
-      version: toolVersion ?? null,
+      version: toolVersion ?? DEFAULT_TOOL_VERSION,
       readableId: toolIdFromTrs(this.defaultToolshedUrl, trsToolId),
     };
   }

--- a/packages/core/test/cache.test.ts
+++ b/packages/core/test/cache.test.ts
@@ -261,9 +261,15 @@ describe("ToolCache", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null version for stock tool without version", () => {
+  it("defaults stock tool without version to the _default_ sentinel", () => {
     const coords = cache.resolveToolCoordinates("cat1");
-    expect(coords.version).toBeNull();
+    expect(coords.version).toBe("_default_");
+  });
+
+  it("defaults built-in (__*__) tool without version to the _default_ sentinel", () => {
+    const coords = cache.resolveToolCoordinates("__APPLY_RULES__");
+    expect(coords.trsToolId).toBe("__APPLY_RULES__");
+    expect(coords.version).toBe("_default_");
   });
 
   it("removeCached deletes one entry by cache key", async () => {


### PR DESCRIPTION
> _Opened by Claude (AI assistant) on behalf of @jmchilton._

## Closes #128

### Root cause (vs. the Python reference)
`#128` framed the bug as "Galaxy built-in `__*__` tools have no concept in resolution" and suggested either an allowlist or bundling schemas. Tracing it against the Python backend (`ToolShedGetToolInfo._resolve_tool_coordinates`) showed the real cause is narrower and simpler: the TS port of `resolveToolCoordinates` **dropped one line**.

| | toolshed branch | stock/built-in branch |
|---|---|---|
| **Python** `_resolve_tool_coordinates` | `tool_version or embedded_version` | `tool_version or "_default_"` |
| **TS (before)** `resolveToolCoordinates` | `toolVersion ?? parsed.toolVersion` | `toolVersion ?? null` ⬅️ diverged |

`null` short-circuited resolution, so stock tools (`cat1`, `Cut1`, `param_value_from_file`) and built-in collection ops (`__APPLY_RULES__`, `__CROSS_PRODUCT_FLAT__`, …) authored without a version were reported `no version for …` and skipped. This was also internally inconsistent: the json-schema validate path already used `_default_` (`validate-workflow-json-schema.ts`), only the core resolver said `null`.

### Fix
Default the stock-tool branch to a `_default_` sentinel (named constant in `tool-cache-defaults.ts`), matching Python. A cache key now forms and the tool resolves through the normal cache/fetch path instead of being skipped. Where no cache/Galaxy-source entry exists, the message degrades from the misleading `no version` to the accurate `not in cache` — same posture as the Python backend (no bundled schemas required, matching the reference).

Scope note: this covers the whole stock/built-in class, not just `__*__` — which is exactly the boundary Python's `else:` branch draws.

### Tests
- Updated `cache.test.ts` to assert the `_default_` sentinel for both a stock tool (`cat1`) and a built-in (`__APPLY_RULES__`); the prior test pinned the divergent `null` behavior.
- Full `core` (122) + `cli` (344) suites green; `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)