### PR TITLE
fix(roundtrip): match steps by label+type to survive reverse-pass renumbering (closes #117)

### DIFF
--- a/.changeset/roundtrip-step-id-mapping.md
+++ b/.changeset/roundtrip-step-id-mapping.md
@@ -1,0 +1,20 @@
+---
+"@galaxy-tool-util/schema": patch
+"@galaxy-tool-util/cli": patch
+---
+
+fix(roundtrip): match steps by label+type so reverse-pass renumbering doesn't misalign diffs
+
+`roundtripValidate` matched original and reimported steps by numeric `id`. But
+format2 stores inputs separately from `steps`, so the reverse (format2→native)
+pass front-loads input steps and renumbers tools — a native step's id is not
+stable across a roundtrip. When inputs were interleaved with tools, the diff
+compared unrelated steps, producing phantom "step missing after roundtrip" and
+value-mismatch errors (e.g. a tool's state diffed against an input, or two
+same-tool steps diffed against each other).
+
+Port Python's `_build_step_id_mapping` (`roundtrip.py`): match by label+type,
+then same-id when the type matches, then a unique tool_id+type fallback for
+unlabeled steps that shifted position, scoped per nesting level. Fixes #117
+(clinicalmp-discovery's apparent peptideshaker step drop + dbbuilder `source`
+mis-selection were both artifacts of this misalignment, not conversion bugs).

--- a/packages/cli/test/stateful-iwc-sweep.test.ts
+++ b/packages/cli/test/stateful-iwc-sweep.test.ts
@@ -53,11 +53,7 @@ function workflowId(path: string): string {
 // Workflows with known error-severity roundtrip diffs, excluded so the sweep
 // flags only NEW regressions. Python's reference roundtrip_validate also fails
 // these (not a TS-only issue). Prune as the upstream conversion bugs are fixed.
-const KNOWN_ROUNDTRIP_FAILURES: ReadonlySet<string> = new Set([
-  // jmchilton/galaxy-tool-util-ts#117 — peptideshaker step drop + dbbuilder
-  // `source` conditional mis-selection on the reverse pass.
-  "proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow.ga",
-]);
+const KNOWN_ROUNDTRIP_FAILURES: ReadonlySet<string> = new Set([]);
 
 interface WorkflowOutcome {
   workflow: string;

--- a/packages/schema/src/workflow/roundtrip.ts
+++ b/packages/schema/src/workflow/roundtrip.ts
@@ -492,6 +492,76 @@ function collectSteps(
   return { tools, subworkflows };
 }
 
+/**
+ * Map original tool-step ids onto their counterparts in the reimported workflow.
+ *
+ * format2 stores inputs separately from `steps`, so the reverse (format2→native)
+ * pass front-loads input steps and renumbers tools — a native step's numeric id
+ * is not stable across a roundtrip. Matching purely by id then compares unrelated
+ * steps. Mirrors Python's `_build_step_id_mapping` (`roundtrip.py`): match by
+ * label+type first, then same-id when the type matches, then a unique tool_id+type
+ * fallback for unlabeled steps that shifted position. Matching is scoped per
+ * nesting level (collected ids are parent-prefixed) so a subworkflow tool can't
+ * match a same-labeled top-level tool. Unmatched original steps map to `null`.
+ */
+function buildStepIdMapping(
+  origSteps: Map<string, CollectedStep>,
+  afterSteps: Map<string, CollectedStep>,
+): Map<string, string | null> {
+  const mapping = new Map<string, string | null>();
+  const usedAfter = new Set<string>();
+  const parentPrefix = (id: string): string =>
+    id.includes(".") ? id.slice(0, id.lastIndexOf(".")) : "";
+
+  // Pass 1: label + type (strongest signal)
+  for (const [origId, { step: orig }] of origSteps) {
+    if (!orig.label) continue;
+    for (const [afterId, { step: after }] of afterSteps) {
+      if (usedAfter.has(afterId)) continue;
+      if (parentPrefix(afterId) !== parentPrefix(origId)) continue;
+      if (after.label === orig.label && after.type === orig.type) {
+        mapping.set(origId, afterId);
+        usedAfter.add(afterId);
+        break;
+      }
+    }
+  }
+
+  // Pass 2: same id when the step type matches
+  for (const [origId, { step: orig }] of origSteps) {
+    if (mapping.has(origId)) continue;
+    const after = afterSteps.get(origId);
+    if (after && !usedAfter.has(origId) && after.step.type === orig.type) {
+      mapping.set(origId, origId);
+      usedAfter.add(origId);
+    }
+  }
+
+  // Pass 3: unique tool_id + type (unlabeled steps that shifted position)
+  for (const [origId, { step: orig }] of origSteps) {
+    if (mapping.has(origId)) continue;
+    if (!orig.tool_id) continue;
+    const candidates: string[] = [];
+    for (const [afterId, { step: after }] of afterSteps) {
+      if (usedAfter.has(afterId)) continue;
+      if (parentPrefix(afterId) !== parentPrefix(origId)) continue;
+      if (after.tool_id === orig.tool_id && after.type === orig.type) {
+        candidates.push(afterId);
+      }
+    }
+    if (candidates.length === 1) {
+      mapping.set(origId, candidates[0]);
+      usedAfter.add(candidates[0]);
+    }
+  }
+
+  // Unmatched → null
+  for (const [origId] of origSteps) {
+    if (!mapping.has(origId)) mapping.set(origId, null);
+  }
+  return mapping;
+}
+
 // --- Public entry point ---
 
 /**
@@ -646,10 +716,12 @@ export function roundtripValidate(
   }
 
   const { tools: reimportedSteps } = collectSteps(reimported);
+  const stepMapping = buildStepIdMapping(originalSteps, reimportedSteps);
 
   // Per-step comparison (top-level + recursively-collected nested tools)
   for (const [stepId, { step: origStep, depth }] of originalSteps) {
-    const afterEntry = reimportedSteps.get(stepId);
+    const afterId = stepMapping.get(stepId);
+    const afterEntry = afterId != null ? reimportedSteps.get(afterId) : undefined;
     if (!afterEntry) {
       stepResults.push({
         stepId,

--- a/packages/schema/test/roundtrip.test.ts
+++ b/packages/schema/test/roundtrip.test.ts
@@ -729,4 +729,80 @@ describe("roundtripValidate", () => {
     expect(result.forwardSteps[0].failureClass).toBe("unknown_tool");
     expect(result.forwardSteps[0].toolVersion).toBe("2.0");
   });
+
+  it("aligns steps by label+type when the reverse pass renumbers them (issue #117)", () => {
+    // format2 stores inputs separately, so the reverse (format2→native) pass
+    // front-loads input steps and renumbers tools. Here inputs sit at ids 0 and
+    // 4 (one before, one *after* the tools); on reimport both move ahead of the
+    // tools, shifting tool ids. Matching by numeric id would (a) compare the
+    // tool at orig id 1 against an input and (b) compare the two same-tool steps
+    // (distinct labels, distinct `count`) against each other → bogus errors.
+    // Label+type matching keeps each step paired with its real counterpart.
+    const toolInputs: ToolParameterModel[] = [dataParam("in", false), intParam("count")];
+    const connected = { __class__: "ConnectedValue" };
+    const dataInput = (id: number, label: string) => ({
+      id,
+      type: "data_input",
+      label,
+      name: label,
+      annotation: "",
+      tool_state: { name: label, optional: false },
+      input_connections: {},
+      inputs: [{ name: label, description: "" }],
+      outputs: [{ name: "output", type: "data" }],
+      workflow_outputs: [],
+      position: { left: 0, top: id * 100 },
+    });
+    const toolStep = (
+      id: number,
+      label: string,
+      toolId: string,
+      count: number,
+      connectTo: number,
+    ) => ({
+      id,
+      type: "tool",
+      label,
+      name: toolId,
+      annotation: "",
+      tool_id: toolId,
+      tool_version: "1.0",
+      tool_state: { in: connected, count },
+      input_connections: { in: [{ id: connectTo, output_name: "output" }] },
+      inputs: [],
+      outputs: [{ name: "out", type: "data" }],
+      workflow_outputs: [],
+      post_job_actions: {},
+      position: { left: 200, top: id * 100 },
+    });
+    const wf: Record<string, unknown> = {
+      a_galaxy_workflow: "true",
+      "format-version": "0.1",
+      name: "renumber",
+      annotation: "",
+      tags: [],
+      steps: {
+        "0": dataInput(0, "in_a"),
+        "1": toolStep(1, "alpha", "single_tool", 1, 0),
+        "2": toolStep(2, "beta-first", "multi_tool", 10, 0),
+        "3": toolStep(3, "beta-second", "multi_tool", 20, 4),
+        "4": dataInput(4, "in_b"),
+      },
+    };
+    const result = roundtripValidate(
+      wf,
+      mapResolver({ single_tool: toolInputs, multi_tool: toolInputs }),
+    );
+
+    // Every tool step found its counterpart — no drops, no cross-step errors.
+    expect(result.stepResults.every((s) => s.success)).toBe(true);
+    expect(
+      result.stepResults.flatMap((s) => s.diffs).filter((d) => d.severity === "error"),
+    ).toEqual([]);
+    // Sanity: the renumbering really happened (beta-second's `count: 20`
+    // survived, not overwritten by beta-first's `count: 10` via a bad match).
+    const betaSecond = result.stepResults.find((s) => s.stepId === "3");
+    expect(betaSecond?.toolId).toBe("multi_tool");
+    expect(betaSecond?.success).toBe(true);
+  });
 });


### PR DESCRIPTION
> _Opened by Claude (AI assistant) on behalf of @jmchilton._

## Closes #117

### Root cause — one bug, not two
#117 reported two failures on `clinicalmp-discovery`: a peptideshaker step "drop" and a dbbuilder `source` conditional "mis-selection" (`cRAP → uniprot`). Both turned out to be **artifacts of a single root cause**, and neither is a conversion bug.

`roundtripValidate` matched original↔reimported steps by numeric `id`. But format2 stores inputs separately from `steps`, so the reverse (format2→native) pass **front-loads input steps and renumbers tools**. In this workflow the inputs sit at original ids `0, 2, 5` (interleaved with tools); on reimport they move to `0, 1, 2`, shifting every early tool id:

| original | reimport (by id) | bogus diff |
|---|---|---|
| `1` ident_params | `1` = data_collection_input | "step 1 missing after roundtrip" |
| `3` dbbuilder "Human SwissProt" (`uniprot`) | `3` = ident_params | "source missing / *_options appeared" |
| `4` dbbuilder "Contaminants" (`cRAP`) | `4` = dbbuilder "Human SwissProt" (`uniprot`) | "cRAP → uniprot" |

I verified the raw state: reimport `id 5` "Contaminants" still holds `cRAP`, and ident_params is alive at reimport `id 3`. The conversion is correct; the **diff** was comparing the wrong pairs.

### Why this diverged from Python
Python's `roundtrip.py` already has `_build_step_id_mapping` with the comment *"match by label+type rather than step ID to handle gxformat2 step reordering."* The TS port never included it — it did `reimportedSteps.get(stepId)`.

### Fix
Port the Python matcher into `roundtripValidate`: label+type → same-id-when-type-matches → unique tool_id+type fallback for unlabeled shifted steps, scoped per nesting level (collected ids are parent-prefixed). Replaces the raw-id lookup.

### Verification
- New hermetic regression test (`roundtrip.test.ts`, "issue #117"): a workflow whose inputs front-load on reimport, with two same-tool steps (distinct labels, distinct state). **Red→green confirmed** — fails with the old by-id lookup, passes with the matcher.
- Real workflow now `success=true` (benign diffs only); dropped from the IWC sweep's `KNOWN_ROUNDTRIP_FAILURES`.
- Full gated IWC roundtrip sweep green with the workflow re-included; `schema` (4915) + `cli` (343) suites green; `make check` clean.

### Note for the issue's "Python also fails" claim
#117 said Python returns `diffs = None`, which (per `full_roundtrip_native`) only happens on a *reimport error* — categorically different from TS's misalignment diffs. So the "shared difficulty" framing likely doesn't hold; if Python genuinely fails here it's at a different stage and worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)