### PR TITLE
feat(schema): export normalizeStepIn / normalizeStepOut

### DIFF
--- a/.changeset/expose-step-shorthand-normalizers.md
+++ b/.changeset/expose-step-shorthand-normalizers.md
@@ -1,0 +1,16 @@
+---
+"@galaxy-tool-util/schema": minor
+---
+
+feat(schema): export `normalizeStepIn` / `normalizeStepOut` step shorthand expanders
+
+The per-step `in:` / `out:` shorthand expansion logic used internally by
+`normalizedFormat2` is now public. Both are pure and value-based (no AST
+awareness), so consumers holding a raw gxformat2 step dict — e.g. the
+VS Code language server walking a parsed document — can reuse the canonical
+shorthand rules instead of re-deriving them.
+
+`normalizeStepIn` covers every form: list-of-strings, list-of-objects,
+map-to-string, map-to-object, and the map-to-list (multi-source) shorthand.
+Pairs with the existing `nativeConnectionsFromFormat2In` to build a native
+connections map from a raw step's `in:` block.

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -100,6 +100,10 @@ export {
   NativeGalaxyWorkflowSchema,
   /** Normalize a raw format2 workflow — fills defaults, resolves implicit fields. */
   normalizedFormat2,
+  /** Expand a step's raw `in` shorthand into normalized {id, source} entries. */
+  normalizeStepIn,
+  /** Expand a step's raw `out` shorthand into normalized {id} entries. */
+  normalizeStepOut,
   NormalizedFormat2WorkflowSchema,
   NormalizedFormat2StepSchema,
   NormalizedFormat2InputSchema,

--- a/packages/schema/src/workflow/index.ts
+++ b/packages/schema/src/workflow/index.ts
@@ -19,6 +19,8 @@ export { galaxyWorkflowDraftJsonSchema } from "./json-schemas.js";
 // Normalized workflow types + normalizers
 export {
   normalizedFormat2,
+  normalizeStepIn,
+  normalizeStepOut,
   NormalizedFormat2WorkflowSchema,
   NormalizedFormat2StepSchema,
   NormalizedFormat2InputSchema,

--- a/packages/schema/src/workflow/normalized/format2.ts
+++ b/packages/schema/src/workflow/normalized/format2.ts
@@ -262,8 +262,8 @@ function _normalizeStep(
   id: string,
   subworkflows: Map<string, Record<string, unknown>>,
 ): NormalizedFormat2Step {
-  const stepIn = _normalizeStepIn(raw.in);
-  const stepOut = _normalizeStepOut(raw.out);
+  const stepIn = normalizeStepIn(raw.in);
+  const stepOut = normalizeStepOut(raw.out);
   const run = _resolveRun(raw.run, subworkflows);
 
   // Resolve $link references in state: replace with ConnectedValue and
@@ -312,7 +312,22 @@ function _normalizeStep(
   };
 }
 
-function _normalizeStepIn(raw: unknown): NormalizedFormat2StepInput[] {
+/**
+ * Expand a step's raw `in` value into normalized `{id, source, ...}` entries,
+ * covering every gxformat2 shorthand:
+ *   - list of strings:   in: [query]                 → {id: "query"}
+ *   - list of objects:   in: [{id: query, source}]   → {id: "query", source}
+ *   - map to string:     in: {query: step/out}        → {id: "query", source}
+ *   - map to list:       in: {query: [a, b]}          → {id: "query", source: [a, b]}
+ *   - map to object:     in: {query: {source, ...}}   → {id: "query", source, ...}
+ *
+ * Pure and value-based (no AST/position awareness) so callers that hold a raw
+ * step dict — e.g. an editor walking a parsed document — can reuse the same
+ * shorthand rules instead of re-deriving them. Note that connections declared
+ * via `{$link: ...}` inside `state` are resolved separately during full step
+ * normalization, not here.
+ */
+export function normalizeStepIn(raw: unknown): NormalizedFormat2StepInput[] {
   if (!raw) return [];
   if (Array.isArray(raw)) {
     return raw.map((item) => {
@@ -341,7 +356,16 @@ function _normalizeStepIn(raw: unknown): NormalizedFormat2StepInput[] {
   return result;
 }
 
-function _normalizeStepOut(raw: unknown): NormalizedFormat2StepOutput[] {
+/**
+ * Expand a step's raw `out` value into normalized `{id, ...}` entries, covering
+ * every gxformat2 shorthand:
+ *   - list of strings:   out: [out_file1]             → {id: "out_file1"}
+ *   - list of objects:   out: [{id: out_file1, ...}]  → {id: "out_file1", ...}
+ *   - map:               out: {out_file1: {...}}      → {id: "out_file1", ...}
+ *
+ * Pure and value-based — see {@link normalizeStepIn}.
+ */
+export function normalizeStepOut(raw: unknown): NormalizedFormat2StepOutput[] {
   if (!raw) return [];
   if (Array.isArray(raw)) {
     return raw.map((item) => {

--- a/packages/schema/src/workflow/normalized/index.ts
+++ b/packages/schema/src/workflow/normalized/index.ts
@@ -1,5 +1,7 @@
 export {
   normalizedFormat2,
+  normalizeStepIn,
+  normalizeStepOut,
   NormalizedFormat2WorkflowSchema,
   NormalizedFormat2StepSchema,
   NormalizedFormat2InputSchema,

--- a/packages/schema/test/normalize-step-shorthand.test.ts
+++ b/packages/schema/test/normalize-step-shorthand.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+
+import { normalizeStepIn, normalizeStepOut } from "../src/workflow/normalized/format2.js";
+
+describe("normalizeStepIn", () => {
+  it("returns [] for a missing in block", () => {
+    expect(normalizeStepIn(undefined)).toEqual([]);
+    expect(normalizeStepIn(null)).toEqual([]);
+  });
+
+  it("expands a list of strings", () => {
+    expect(normalizeStepIn(["query"])).toEqual([{ id: "query" }]);
+  });
+
+  it("expands a list of objects", () => {
+    expect(normalizeStepIn([{ id: "query", source: "step1/out" }])).toEqual([
+      { id: "query", source: "step1/out" },
+    ]);
+  });
+
+  it("expands map-to-string shorthand", () => {
+    expect(normalizeStepIn({ query: "step1/out" })).toEqual([{ id: "query", source: "step1/out" }]);
+  });
+
+  it("expands map-to-object shorthand", () => {
+    expect(normalizeStepIn({ query: { source: "step1/out" } })).toEqual([
+      { id: "query", source: "step1/out" },
+    ]);
+  });
+
+  it("expands map-to-list (multi-source) shorthand", () => {
+    expect(normalizeStepIn({ query: ["a/out", "b/out"] })).toEqual([
+      { id: "query", source: ["a/out", "b/out"] },
+    ]);
+  });
+
+  it("keeps an entry with no source", () => {
+    expect(normalizeStepIn({ query: null })).toEqual([{ id: "query" }]);
+  });
+});
+
+describe("normalizeStepOut", () => {
+  it("returns [] for a missing out block", () => {
+    expect(normalizeStepOut(undefined)).toEqual([]);
+  });
+
+  it("expands a list of strings", () => {
+    expect(normalizeStepOut(["out_file1", "out_file2"])).toEqual([
+      { id: "out_file1" },
+      { id: "out_file2" },
+    ]);
+  });
+
+  it("expands a list of objects", () => {
+    expect(normalizeStepOut([{ id: "out_file1", hide: true }])).toEqual([
+      { id: "out_file1", hide: true },
+    ]);
+  });
+
+  it("expands the map form", () => {
+    expect(normalizeStepOut({ out_file1: { hide: true }, out_file2: {} })).toEqual([
+      { id: "out_file1", hide: true },
+      { id: "out_file2" },
+    ]);
+  });
+});


### PR DESCRIPTION
> **Note:** opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

## What

Promotes the per-step `in:` / `out:` shorthand expanders used internally by `normalizedFormat2` to **public API**:

- **`normalizeStepIn(raw)`** → `NormalizedFormat2StepInput[]` — handles every form: list-of-strings, list-of-objects, map→string, map→object, and map→list (multi-source).
- **`normalizeStepOut(raw)`** → `NormalizedFormat2StepOutput[]` — list-of-strings, list-of-objects, map.

Both are pure and value-based (no AST/position awareness) and re-exported from `workflow/index.ts` and the package root.

## Why

The gxformat2 `in:`/`out:` shorthand rules were private, so consumers holding a raw step dict had to re-derive them. The VS Code language server (`galaxy-workflows-vscode`) currently re-implements a subset of `normalizeStepIn` and was missing the map→list (multi-source) form. Exposing these lets it reuse the canonical rules. `normalizeStepIn` pairs with the existing `nativeConnectionsFromFormat2In` to build a native connections map from a raw step's `in:` block.

Deliberately *not* exposed: `_normalizeSteps` (recursive, resolves run/subworkflows/`$link`, discards positions — step iteration stays AST-bound in consumers).

## Tests

New `test/normalize-step-shorthand.test.ts` (11 cases, all forms incl. multi-source). Schema lint/format/`tsc`/full suite green (4926 passed). Changeset: **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)