### PR TITLE
fix(cache): resolve unversioned stock tools against the shed (keep _default_ key)

### DIFF
--- a/.changeset/stock-tool-default-resolution.md
+++ b/.changeset/stock-tool-default-resolution.md
@@ -1,0 +1,19 @@
+---
+"@galaxy-tool-util/core": patch
+---
+
+fix(cache): resolve a concrete version for unversioned stock tools while keying under `_default_`
+
+`getToolInfo` treated the `_default_` sentinel as a literal version: an unversioned
+stock-tool request (`add Filter1`) fetched `…/versions/_default_` (404) and never
+attempted version discovery, because a non-null `_default_` short-circuited
+`resolveLatestVersion`.
+
+`getToolInfo` now treats `_default_` as a cache-**key** placeholder, not a fetch version.
+On a cache miss it resolves a concrete version (e.g. `Filter1` → `1.1.1`) for the network
+request and records it as the entry's display version (so `list` surfaces it), while
+keeping the entry **keyed** under `_default_` so the offline json-schema validate path
+still gets cache hits. Genuinely versionless built-ins (`__APPLY_RULES__`) fall back to the
+`_default_` sentinel for the fetch when the shed lists no versions. The cache lookup happens
+before any discovery, so `_default_` cache hits stay network-free. `refetch` no longer
+reports a non-existent `~<version>` key for stock tools.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -16,7 +16,7 @@ All commands accept `--cache-dir <dir>` to override the cache directory.
 | Command | Flag | Default | Description |
 |---|---|---|---|
 | `add` | `--tool-version <ver>` | — | Tool version |
-| `add` | `--galaxy-url <url>` | — | Galaxy instance URL for fallback |
+| `add` | `--galaxy-url <url>` | — | Alternate Galaxy source, tried after the ToolShed |
 | `list` | `--json` | `false` | JSON output |
 | `info` | `--tool-version <ver>` | — | Tool version |
 | `schema` | `--tool-version <ver>` | — | Tool version |

--- a/docs/guide/tool-caching.md
+++ b/docs/guide/tool-caching.md
@@ -47,6 +47,23 @@ galaxy-tool-cache clear
 galaxy-tool-cache clear fastqc
 ```
 
+## Stock and Built-in Tools
+
+Galaxy's stock/built-in tools — `Filter1`, `sort1`, `Cut1`, `Show beginning1`, collection
+operations like `__APPLY_RULES__`, datatype converters — use **bare tool IDs** (no
+`owner/repo/tool` ToolShed path). The ToolShed serves these too, so they resolve with the
+bare ID:
+
+```bash
+# Stock tools resolve by bare ID against the ToolShed (not just shed-path tools)
+galaxy-tool-cache add Filter1 --tool-version 1.1.1
+galaxy-tool-cache summarize "Show beginning1" --tool-version 1.0.2
+```
+
+Pass `--tool-version` for stock tools while the shed's TRS version-list endpoint is
+unavailable; once a stock tool is cached, `summarize`/`info`/`schema` resolve it from the
+bare ID. Unversioned built-ins (`__APPLY_RULES__`) are keyed under a `_default_` sentinel.
+
 ## Pre-Populating for CI
 
 For CI environments, pre-populate the cache with all tools referenced by your workflows:

--- a/docs/packages/cli.md
+++ b/docs/packages/cli.md
@@ -15,13 +15,15 @@ Fetch a tool from [ToolShed](https://toolshed.g2.bx.psu.edu) or Galaxy and cache
 ```bash
 galaxy-tool-cache add toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc --tool-version 0.74+galaxy0
 galaxy-tool-cache add toolshed.g2.bx.psu.edu/repos/iuc/bcftools_norm/bcftools_norm --tool-version 1.15.1+galaxy3
+# Stock/built-in tools resolve by bare ID against the ToolShed too
+galaxy-tool-cache add Filter1 --tool-version 1.1.1
 ```
 
 | Option | Description |
 |---|---|
-| `--tool-version <ver>` | Tool version (required for ToolShed tools) |
+| `--tool-version <ver>` | Tool version (required for ToolShed tools; pass for stock tools too while the shed version-list endpoint is down) |
 | `--cache-dir <dir>` | Override cache directory |
-| `--galaxy-url <url>` | Galaxy instance URL for fallback fetching |
+| `--galaxy-url <url>` | Alternate Galaxy source, tried after the ToolShed |
 
 ### `list`
 
@@ -96,14 +98,14 @@ Scan a workflow file, extract all tool references, and cache each one.
 # Cache all tools referenced in a workflow
 galaxy-tool-cache populate-workflow my-workflow.ga
 
-# With Galaxy fallback for tools not on ToolShed
+# With an extra Galaxy source (e.g. an instance-local tool absent from the ToolShed)
 galaxy-tool-cache populate-workflow my-workflow.gxwf.yml --galaxy-url https://usegalaxy.org
 ```
 
 | Option | Description |
 |---|---|
 | `--cache-dir <dir>` | Cache directory |
-| `--galaxy-url <url>` | Galaxy instance URL for fallback fetching |
+| `--galaxy-url <url>` | Alternate Galaxy source, tried after the ToolShed |
 
 ## gxwf
 

--- a/packages/core/src/tool-info.ts
+++ b/packages/core/src/tool-info.ts
@@ -1,5 +1,5 @@
 import type { ParsedTool } from "@galaxy-tool-util/schema";
-import { ToolCache } from "./cache/tool-cache.js";
+import { DEFAULT_TOOL_VERSION, ToolCache } from "./cache/tool-cache.js";
 import { cacheKey } from "./cache/cache-key.js";
 import { fetchFromToolShed, fetchFromGalaxy } from "./client/toolshed.js";
 import { getLatestTRSToolVersion } from "./client/trs.js";
@@ -56,19 +56,35 @@ export class ToolInfoService {
 
   async getToolInfo(toolId: string, toolVersion?: string | null): Promise<ParsedTool | null> {
     const coords = this.cache.resolveToolCoordinates(toolId, toolVersion);
-    let resolvedVersion = coords.version;
-    if (resolvedVersion === null) {
-      resolvedVersion = await this.resolveLatestVersion(coords.toolshedUrl, coords.trsToolId);
-      if (resolvedVersion === null) {
+    // `keyVersion` keys the cache entry. The `_default_` sentinel is a stable handle
+    // for an unversioned stock/built-in request and must survive as the key so the
+    // offline json-schema validate path (which keys by `_default_`) gets cache hits.
+    let keyVersion = coords.version;
+    if (keyVersion === null) {
+      // ToolShed tool without a pin — must resolve a concrete version before we can key it.
+      const resolved = await this.resolveLatestVersion(coords.toolshedUrl, coords.trsToolId);
+      if (resolved === null) {
         console.debug(`No version available for tool: ${toolId}`);
         return null;
       }
+      keyVersion = resolved;
     }
-    const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, resolvedVersion);
+    const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, keyVersion);
 
-    // Check storage cache (ToolCache checks memory first internally)
+    // Check storage cache (ToolCache checks memory first internally). Done before any
+    // `_default_` version discovery so cache hits stay network-free.
     const cached = await this.cache.loadCached(key);
     if (cached !== null) return cached;
+
+    // Cache miss — pick the concrete version actually requested from the remote. For a
+    // `_default_` request, resolve one now while keeping the key as `_default_`; fall back
+    // to the sentinel when the shed can't list versions (genuinely versionless built-ins
+    // like __APPLY_RULES__).
+    let fetchVersion = keyVersion;
+    if (keyVersion === DEFAULT_TOOL_VERSION) {
+      const resolved = await this.resolveLatestVersion(coords.toolshedUrl, coords.trsToolId);
+      fetchVersion = resolved ?? DEFAULT_TOOL_VERSION;
+    }
 
     // Try each source in order
     for (const source of this.sources) {
@@ -81,22 +97,26 @@ export class ToolInfoService {
           parsedTool = await fetchFromToolShed(
             source.url,
             coords.trsToolId,
-            resolvedVersion,
+            fetchVersion,
             this.fetcher,
           );
           sourceLabel = "api";
-          sourceUrl = `${source.url}/api/tools/${coords.trsToolId}/versions/${resolvedVersion}`;
+          sourceUrl = `${source.url}/api/tools/${coords.trsToolId}/versions/${fetchVersion}`;
         } else {
-          parsedTool = await fetchFromGalaxy(source.url, toolId, resolvedVersion, this.fetcher);
+          parsedTool = await fetchFromGalaxy(source.url, toolId, fetchVersion, this.fetcher);
           sourceLabel = "galaxy";
           sourceUrl = `${source.url}/api/tools/${encodeURIComponent(toolId)}/parsed`;
         }
 
+        // Key under `keyVersion` (may be `_default_`); record the concrete version the
+        // body reports (falling back to `fetchVersion`) as the index/display version so
+        // `list` surfaces it.
+        const indexVersion = parsedTool.version ?? fetchVersion;
         await this.cache.saveTool(
           key,
           parsedTool,
           coords.readableId,
-          resolvedVersion,
+          indexVersion,
           sourceLabel,
           sourceUrl,
         );
@@ -143,7 +163,7 @@ export class ToolInfoService {
     opts?: { force?: boolean },
   ): Promise<{ cacheKey: string; fetched: boolean; alreadyCached: boolean }> {
     const coords = this.cache.resolveToolCoordinates(toolId, toolVersion ?? null);
-    let resolvedVersion = coords.version;
+    const resolvedVersion = coords.version;
     let alreadyCached = false;
     if (resolvedVersion !== null) {
       alreadyCached = await this.cache.hasCached(toolId, resolvedVersion);
@@ -160,8 +180,18 @@ export class ToolInfoService {
     if (tool === null) {
       throw new Error(`Failed to fetch tool: ${toolId}`);
     }
-    resolvedVersion = tool.version ?? resolvedVersion ?? "unknown";
-    const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, resolvedVersion);
+    // Mirror getToolInfo's keying: `_default_` and explicit pins key as-is
+    // (coords.version); an unpinned ToolShed tool (coords.version === null) keys by the
+    // resolved version. Must not key a stock tool by tool.version — its entry lives under
+    // the `_default_` key, not `~<version>`.
+    //
+    // Known edge (tracked): a stock entry is keyed under `_default_` but its index/display
+    // version is the concrete one (e.g. `1.1.1`). A caller that refetches by the *display*
+    // version (gxwf-web inspector does) passes `1.1.1`, misses the `_default_` key, and
+    // writes a duplicate sibling instead of refreshing. Unreachable until the shed's TRS
+    // version-list endpoint is healthy; fix needs the request version persisted in the index.
+    const keyVersion = coords.version ?? tool.version ?? "unknown";
+    const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, keyVersion);
     return { cacheKey: key, fetched: true, alreadyCached };
   }
 

--- a/packages/core/test/tool-info.test.ts
+++ b/packages/core/test/tool-info.test.ts
@@ -138,6 +138,91 @@ describe("ToolInfoService", () => {
     expect(result).toBeNull();
   });
 
+  it("resolves a concrete version for an unversioned stock id but keys the entry under _default_", async () => {
+    const stockBody = {
+      ...(fastqcFixture as any),
+      id: "Filter1",
+      name: "Filter",
+      version: "1.1.1",
+    };
+    let versionsFetched = 0;
+    let toolFetched = 0;
+    let toolFetchUrl = "";
+    const fetcher: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      if (url.includes("/api/ga4gh/trs/v2/tools/")) {
+        versionsFetched++;
+        return new Response(
+          JSON.stringify([
+            {
+              id: "1.1.0",
+              name: null,
+              url: "https://example/tool",
+              descriptor_type: ["GALAXY"],
+              author: [],
+            },
+            {
+              id: "1.1.1",
+              name: null,
+              url: "https://example/tool",
+              descriptor_type: ["GALAXY"],
+              author: [],
+            },
+          ]),
+          { status: 200 },
+        );
+      }
+      toolFetched++;
+      toolFetchUrl = url;
+      return new Response(JSON.stringify(stockBody), { status: 200 });
+    };
+    const service = makeNodeToolInfoService({ cacheDir: tmpDir, fetcher });
+
+    const result = await service.getToolInfo("Filter1");
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe("1.1.1");
+    // fetched the concrete version, not the `_default_` sentinel
+    expect(toolFetchUrl).toContain("/versions/1.1.1");
+    expect(versionsFetched).toBe(1);
+    expect(toolFetched).toBe(1);
+
+    // keyed under `_default_`: a no-version lookup is a cache hit with no extra fetch
+    const cached = await service.getToolInfo("Filter1");
+    expect(cached).not.toBeNull();
+    expect(versionsFetched).toBe(1);
+    expect(toolFetched).toBe(1);
+    expect(await service.cache.hasCached("Filter1")).toBe(true);
+
+    // index/display version is the concrete one so `list` surfaces it
+    const entries = await service.cache.index.listAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].tool_version).toBe("1.1.1");
+  });
+
+  it("falls back to the _default_ sentinel for the fetch when the shed lists no versions", async () => {
+    const builtinBody = {
+      ...(fastqcFixture as any),
+      id: "__APPLY_RULES__",
+      name: "Apply rules",
+      version: null,
+    };
+    let toolFetchUrl = "";
+    const fetcher: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      if (url.includes("/api/ga4gh/trs/v2/tools/")) {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      toolFetchUrl = url;
+      return new Response(JSON.stringify(builtinBody), { status: 200 });
+    };
+    const service = makeNodeToolInfoService({ cacheDir: tmpDir, fetcher });
+
+    const result = await service.getToolInfo("__APPLY_RULES__");
+    expect(result).not.toBeNull();
+    expect(toolFetchUrl).toContain("/versions/_default_");
+    expect(await service.cache.hasCached("__APPLY_RULES__")).toBe(true);
+  });
+
   it("resolves the latest TRS version when the caller omits one", async () => {
     let versionsFetched = 0;
     let toolFetched = 0;


### PR DESCRIPTION
## Problem

`galaxy-tool-cache add <stock_id>` for bare/built-in ids (`Filter1`, `cat1`, `Cut1`, collection ops) couldn't resolve a version. `getToolInfo` treated the `_default_` sentinel (introduced in #128 / `c427e627`) as a literal fetch version, so a bare `add Filter1` fetched `/api/tools/Filter1/versions/_default_` → 404 and never attempted version discovery.

The Tool Shed **does** serve stock tools — `GET /api/tools/Filter1/versions/1.1.1` → 200 — so routing bare ids to the shed is correct; the gap was purely client-side version handling.

## Change

`_default_` is now a cache-**key** placeholder, not a fetch version:

- On a cache miss, resolve a concrete version (`Filter1` → `1.1.1`) for the network request and record it as the entry's **display/index** version (so `list` surfaces it), while keeping the entry **keyed** under `_default_` — so the offline json-schema validate path (which keys no-version steps by `_default_`) keeps hitting cache.
- The cache lookup happens **before** any discovery, so `_default_` cache hits stay network-free.
- Genuinely versionless built-ins (`__APPLY_RULES__`) fall back to the `_default_` sentinel for the fetch when the shed lists no versions.
- `refetch` returns the key the entry is actually stored under, not a bogus `~<version>`.

## Docs

- `tool-caching.md`: new "Stock and Built-in Tools" section (bare ids resolve against the shed).
- `configuration.md` / `cli.md`: `--galaxy-url` reframed from "fallback" to "alternate source, tried after the ToolShed"; bare stock-id example added.

## Tests

Two new `tool-info` tests (concrete-resolution-but-`_default_`-keying; versionless fallback). Core 124/124, CLI 344/344. `make check` green.

## Notes

- Bare `add Filter1` **auto-version** still can't succeed until the shed's TRS version-list endpoint (`/api/ga4gh/trs/v2/tools/<id>/versions`) is healthy — it currently 500s shed-wide. The works-today path is `add Filter1 --tool-version 1.1.1`. This change makes auto-version correct for when the shed recovers.
- Known follow-up edge tracked in #135 (gxwf-web refetch of a `_default_`-keyed stock entry can duplicate it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)