### PR TITLE
fix(cli): align galaxy-tool-cache --help with documented stock-tool behavior

### DIFF
--- a/.changeset/galaxy-tool-cache-spec-descriptions.md
+++ b/.changeset/galaxy-tool-cache-spec-descriptions.md
@@ -1,0 +1,17 @@
+---
+"@galaxy-tool-util/cli": patch
+---
+
+fix(cli): correct `galaxy-tool-cache` command/option help to match documented behavior
+
+The CLI spec (`spec/galaxy-tool-cache.json`) — the single source the commander program,
+`--help`, and the browser-safe `meta` API are all built from — still described
+`--galaxy-url` as a "fallback" and `add` as fetching from "ToolShed/Galaxy", contradicting
+the guide docs updated in #136. Stock/built-in bare IDs resolve against the ToolShed, so:
+
+- `add` description and `<tool_id>` arg now state bare/stock IDs are supported.
+- `--galaxy-url` reworded to "Alternate Galaxy source, tried after the ToolShed" (matches
+  `docs/guide/configuration.md` and `docs/packages/cli.md`).
+- `list` description notes it surfaces resolved versions (the stock-version discovery surface).
+
+Help text and docs no longer disagree; no behavior change.

--- a/packages/cli/spec/galaxy-tool-cache.json
+++ b/packages/cli/spec/galaxy-tool-cache.json
@@ -5,12 +5,12 @@
   "commands": [
     {
       "name": "add",
-      "description": "Fetch a tool from ToolShed/Galaxy and cache it",
+      "description": "Fetch a tool from the ToolShed (shed-path or bare/stock ID) and cache it",
       "handler": "add",
       "args": [
         {
           "raw": "<tool_id>",
-          "description": "Tool ID (full toolshed path or TRS ID)"
+          "description": "Tool ID: shed path (owner/repo/tool), TRS ID, or bare/stock ID (e.g. Filter1)"
         }
       ],
       "options": [
@@ -24,13 +24,13 @@
         },
         {
           "flags": "--galaxy-url <url>",
-          "description": "Galaxy instance URL for fallback"
+          "description": "Alternate Galaxy source, tried after the ToolShed"
         }
       ]
     },
     {
       "name": "list",
-      "description": "List cached tools",
+      "description": "List cached tools with their resolved versions",
       "handler": "list",
       "options": [
         {
@@ -153,7 +153,7 @@
         },
         {
           "flags": "--galaxy-url <url>",
-          "description": "Galaxy instance URL for fallback"
+          "description": "Alternate Galaxy source, tried after the ToolShed"
         }
       ]
     }


### PR DESCRIPTION
## Problem

#136 fixed stock/built-in bare-ID resolution and updated the **guide docs**, but left the **CLI spec** (`packages/cli/spec/galaxy-tool-cache.json`) stale. That spec is the single source the commander program, `--help`, *and* the browser-safe `meta` API are all built from (`buildProgramFromSpec`) — and it's what downstream consumers (e.g. the Galaxy Workflow Foundry) cite as the `upstream:` authority for their CLI reference pages.

So after #136, `--help` directly contradicted the docs:

- `--galaxy-url` → `"Galaxy instance URL for fallback"`, but `docs/guide/configuration.md` + `docs/packages/cli.md` now say "Alternate Galaxy source, tried after the ToolShed".
- `add` → `"Fetch a tool from ToolShed/Galaxy and cache it"`, with no hint that bare/stock IDs (`Filter1`, `Cut1`, …) resolve against the shed.
- `list` → `"List cached tools"`, not signalling it's the version-discovery surface for stock tools.

A docs-only change can't reach agents driving the CLI via `--help` or the `meta` API; both read the spec.

## Change

Spec descriptions only (no behavior change):

- `add` description + `<tool_id>` arg: state bare/stock IDs are supported.
- `--galaxy-url` (on `add` and `populate-workflow`): reworded to match the docs.
- `list` description: notes it surfaces resolved versions.

The in-code program builder is built *from* this spec, so the spec-parity test covers both sides automatically.

## Tests

CLI 344/344, `tsc --noEmit` clean, prettier clean. Verified `add --help` / `list --help` render the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)