### PR TITLE
fix(schema): strip derived in-memory fields from serialized workflows

### DIFF
--- a/.changeset/strip-derived-workflow-fields.md
+++ b/.changeset/strip-derived-workflow-fields.md
@@ -1,0 +1,14 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+fix(schema): stop leaking derived in-memory fields into serialized workflows
+
+`serializeWorkflow` now strips the normalization-only fields `unique_tools`
+(workflow level) and `connected_paths` (step level) before emitting. These are
+`Set`s built during normalization and never part of the on-disk Galaxy format;
+serializing a `Set` produced a stray `{}` / empty mapping that downstream schema
+validators (e.g. VS Code's Native Workflow Schema) reject. The strip walks the
+workflow structurally — including native `subworkflow` and format2 `run` embeds —
+so a tool parameter literally named `unique_tools`/`connected_paths` inside
+`tool_state` is preserved. Fixes stray keys in `gxwf convert` output.

--- a/packages/schema/src/workflow/serialize.ts
+++ b/packages/schema/src/workflow/serialize.ts
@@ -8,6 +8,53 @@
 import { stringify as stringifyYaml } from "yaml";
 import { detectFormat, type WorkflowFormat } from "./detect-format.js";
 
+/**
+ * In-memory-only fields derived during normalization (see
+ * `workflow/normalized/native.ts` and `format2.ts`). They are never part of
+ * the on-disk Galaxy format: `unique_tools` is a workflow-level `Set` of tool
+ * references, `connected_paths` is a per-step `Set` of input-connection keys.
+ * Serializing a `Set` yields `{}` (JSON) / an empty mapping (YAML), so left in
+ * place they leak as stray keys that downstream schema validators reject.
+ *
+ * Stripped structurally (workflow level / step level / subworkflows) rather
+ * than by a blanket recursive key match so a tool parameter that happens to be
+ * named `unique_tools`/`connected_paths` inside `tool_state` is preserved.
+ */
+function stripDerivedFields(data: Record<string, unknown>): Record<string, unknown> {
+  return stripWorkflowDict(data);
+}
+
+function stripWorkflowDict(wf: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...wf };
+  delete out.unique_tools;
+  if (out.steps && typeof out.steps === "object") {
+    out.steps = stripSteps(out.steps as Record<string, unknown> | unknown[]);
+  }
+  return out;
+}
+
+function stripSteps(
+  steps: Record<string, unknown> | unknown[],
+): Record<string, unknown> | unknown[] {
+  if (Array.isArray(steps)) return steps.map(stripStep);
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(steps)) out[key] = stripStep(value);
+  return out;
+}
+
+function stripStep(step: unknown): unknown {
+  if (step == null || typeof step !== "object") return step;
+  const out = { ...(step as Record<string, unknown>) };
+  delete out.connected_paths;
+  // Embedded subworkflows: `subworkflow` (native) / `run` (format2).
+  for (const key of ["subworkflow", "run"] as const) {
+    if (out[key] && typeof out[key] === "object") {
+      out[key] = stripWorkflowDict(out[key] as Record<string, unknown>);
+    }
+  }
+  return out;
+}
+
 export interface SerializeWorkflowOptions {
   /** Force JSON output regardless of format. */
   json?: boolean;
@@ -36,6 +83,7 @@ export function serializeWorkflow(
   format: WorkflowFormat,
   opts: SerializeWorkflowOptions = {},
 ): string {
+  data = stripDerivedFields(data);
   const useYaml = opts.yaml || (!opts.json && format === "format2");
   const newline = opts.trailingNewline ?? true;
   if (useYaml) {

--- a/packages/schema/test/serialize.test.ts
+++ b/packages/schema/test/serialize.test.ts
@@ -30,3 +30,42 @@ describe("serializeWorkflow format2 YAML", () => {
     expect(out).toContain("label: hello");
   });
 });
+
+describe("serializeWorkflow strips derived in-memory fields", () => {
+  it("drops workflow-level unique_tools and step-level connected_paths", () => {
+    const data = {
+      steps: {
+        "0": { tool_id: "cat", connected_paths: new Set(["input"]) },
+      },
+      unique_tools: new Set([{ tool_id: "cat", tool_version: null }]),
+    };
+    const out = serializeWorkflow(data, "native", { json: true });
+    expect(out).not.toContain("unique_tools");
+    expect(out).not.toContain("connected_paths");
+  });
+
+  it("recurses into native subworkflow and format2 run embeds", () => {
+    const data = {
+      steps: {
+        "0": {
+          connected_paths: new Set(),
+          subworkflow: { steps: { "0": { connected_paths: new Set() } }, unique_tools: new Set() },
+        },
+        "1": {
+          run: { steps: [{ connected_paths: new Set() }], unique_tools: new Set() },
+        },
+      },
+      unique_tools: new Set(),
+    };
+    const out = serializeWorkflow(data, "format2");
+    expect(out).not.toContain("unique_tools");
+    expect(out).not.toContain("connected_paths");
+  });
+
+  it("preserves a tool_state param literally named unique_tools", () => {
+    const data = { steps: { "0": { tool_state: { unique_tools: "keep-me" } } } };
+    const out = serializeWorkflow(data, "native", { json: true });
+    expect(out).toContain("unique_tools");
+    expect(out).toContain("keep-me");
+  });
+});


### PR DESCRIPTION
## Problem

`gxwf convert` (and any other write path) leaks normalization-only fields into serialized workflows:

- `unique_tools` — a workflow-level `Set` of tool references
- `connected_paths` — a per-step `Set` of input-connection keys

Both are derived during normalization (`workflow/normalized/native.ts`, `format2.ts`) and are **never** part of the on-disk Galaxy format. Serializing a `Set` produces a stray `{}` (JSON) / empty mapping (YAML), so converted files carry bogus `connected_paths: {}` on every step and an `unique_tools` blob. Downstream validators — e.g. VS Code's Native Workflow Schema (`additionalProperties: false`) — reject the result.

## Fix

`serializeWorkflow` (the chokepoint shared by `convert`, `convert-tree`, `clean`, `draft-extract`, and gxwf-web) now strips these fields before emitting. The strip is **structural** — it walks workflow → steps → embedded subworkflows (native `subworkflow`, format2 `run`) — rather than a blanket recursive key match, so a tool parameter literally named `unique_tools`/`connected_paths` inside `tool_state` is preserved.

Scope is deliberately "don't write new bad files" — existing on-disk files are not repaired by `clean` (no consumers of the bad output exist).

## Tests

- 3 regression tests in `serialize.test.ts`: top-level strip, subworkflow/`run` recursion, and tool_state false-positive preservation.
- Full suite green (`make test`), `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)