### PR TITLE
fix(schema): typed StringContainerError + located diagnostic for string-valued container param

### DIFF
--- a/.changeset/typed-string-container-error.md
+++ b/.changeset/typed-string-container-error.md
@@ -1,0 +1,19 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+fix(schema): emit a located diagnostic instead of throwing on a string-valued container parameter
+
+The schema-aware walker rejects a scalar where a container parameter
+(`gx_section`/`gx_repeat`/`gx_conditional`) is expected. It now throws a typed
+`StringContainerError` carrying the offending parameter's flat state path and
+container type, instead of a bare `Error` whose only structured data lived in
+the English message — mirroring the existing `UnknownKeyError`.
+
+The tool-state validators whose contract is to _return_ diagnostics
+(`validateFormat2StepStateStrict`, `ToolStateValidator.validateNativeStep` /
+`validateFormat2Step`) now catch `StringContainerError` and map it to a located
+`ToolStateDiagnostic` (dot-separated path), so one malformed step no longer
+crashes the whole validation pass. Conversion paths still throw, and the error
+message is unchanged so existing `message.includes("legacy parameter encoding")`
+consumers keep working.

--- a/packages/schema/src/tool-state-validator.ts
+++ b/packages/schema/src/tool-state-validator.ts
@@ -2,11 +2,13 @@ import type { ParsedTool } from "./schema/parsed-tool.js";
 import type { ToolParameterModel } from "./schema/bundle-types.js";
 import {
   ConversionValidationFailure,
+  stringContainerDiagnostic,
   validateFormat2StepState,
   validateFormat2StepStateStrict,
   validateNativeStepState,
   type ToolStateDiagnostic,
 } from "./workflow/stateful-validate.js";
+import { StringContainerError } from "./workflow/walker.js";
 
 // Re-export so consumers can import the type from this module without
 // needing to know its definition lives in stateful-validate.
@@ -43,6 +45,9 @@ export class ToolStateValidator {
       if (e instanceof ConversionValidationFailure) {
         return e.issues.map((msg) => ({ path: "", message: msg, severity: "error" as const }));
       }
+      if (e instanceof StringContainerError) {
+        return [stringContainerDiagnostic(e)];
+      }
       throw e;
     }
   }
@@ -61,6 +66,9 @@ export class ToolStateValidator {
     } catch (e) {
       if (e instanceof ConversionValidationFailure) {
         return e.issues.map((msg) => ({ path: "", message: msg, severity: "error" as const }));
+      }
+      if (e instanceof StringContainerError) {
+        return [stringContainerDiagnostic(e)];
       }
       throw e;
     }

--- a/packages/schema/src/workflow/index.ts
+++ b/packages/schema/src/workflow/index.ts
@@ -107,6 +107,7 @@ export {
   walkFormat2State,
   SKIP_VALUE,
   UnknownKeyError,
+  StringContainerError,
   type LeafCallback,
   type WalkNativeOptions,
 } from "./walker.js";

--- a/packages/schema/src/workflow/stateful-validate.ts
+++ b/packages/schema/src/workflow/stateful-validate.ts
@@ -20,6 +20,7 @@ import "../schema/parameters/index.js";
 import { createFieldModel } from "../schema/model-factory.js";
 import type { ToolParameterBundleModel, ToolParameterModel } from "../schema/bundle-types.js";
 import { injectConnectionsIntoState, stripConnectedValues } from "./state-merge.js";
+import { StringContainerError } from "./walker.js";
 
 export type ValidationPhase = "pre" | "post";
 
@@ -126,6 +127,20 @@ export interface ToolStateDiagnostic {
 }
 
 /**
+ * Map a {@link StringContainerError} thrown by the walker into a located
+ * diagnostic. The walker joins nested paths with `|`; diagnostics use `.` to
+ * match the Effect Schema issue paths, so normalize the separator here.
+ */
+export function stringContainerDiagnostic(error: StringContainerError): ToolStateDiagnostic {
+  const path = error.path.split("|").join(".");
+  return {
+    path,
+    message: `Invalid value for "${path}": expected a nested object or list, not a plain value.`,
+    severity: "error",
+  };
+}
+
+/**
  * Strict variant of {@link validateFormat2StepState}: reports unknown keys as
  * diagnostics rather than silently ignoring them.
  *
@@ -142,7 +157,17 @@ export function validateFormat2StepStateStrict(
   if (!model) return [];
 
   const state = deepClone(format2State);
-  stripConnectedValues(inputs, state);
+  // The walker rejects a scalar where a container is expected by throwing; the
+  // strict validator's contract is to *return* diagnostics, so map it instead
+  // of letting it crash the whole validation pass.
+  try {
+    stripConnectedValues(inputs, state);
+  } catch (error) {
+    if (error instanceof StringContainerError) {
+      return [stringContainerDiagnostic(error)];
+    }
+    throw error;
+  }
 
   const decode = S.decodeUnknownEither(model as S.Schema<unknown>, { onExcessProperty: "error" });
   const result = decode(state);

--- a/packages/schema/src/workflow/walker.ts
+++ b/packages/schema/src/workflow/walker.ts
@@ -86,7 +86,7 @@ export function walkNativeState(
       const conditional = toolInput as ConditionalParameterModel;
       const conditionalState = state[name];
 
-      _assertNotStringContainer(name, parameterType, conditionalState);
+      _assertNotStringContainer(statePath, parameterType, conditionalState);
       const stateDict = (conditionalState as Record<string, unknown>) ?? {};
 
       const when = selectWhichWhen(conditional, stateDict);
@@ -108,7 +108,7 @@ export function walkNativeState(
       const repeat = toolInput as RepeatParameterModel;
       const repeatState = state[name];
 
-      _assertNotStringContainer(name, parameterType, repeatState);
+      _assertNotStringContainer(statePath, parameterType, repeatState);
 
       // Determine instance count from state array or input connections
       const stateArray = Array.isArray(repeatState)
@@ -146,7 +146,7 @@ export function walkNativeState(
       const section = toolInput as SectionParameterModel;
       const sectionState = state[name];
 
-      _assertNotStringContainer(name, parameterType, sectionState);
+      _assertNotStringContainer(statePath, parameterType, sectionState);
       const stateDict = (sectionState as Record<string, unknown>) ?? {};
 
       const innerResult = walkNativeState(
@@ -213,7 +213,7 @@ export function walkFormat2State(
       const conditional = toolInput as ConditionalParameterModel;
       const conditionalState = state[name];
 
-      _assertNotStringContainer(name, parameterType, conditionalState);
+      _assertNotStringContainer(statePath, parameterType, conditionalState);
       const stateDict = (conditionalState as Record<string, unknown>) ?? {};
 
       const when = selectWhichWhen(conditional, stateDict);
@@ -233,7 +233,7 @@ export function walkFormat2State(
       const repeat = toolInput as RepeatParameterModel;
       const repeatState = state[name];
 
-      _assertNotStringContainer(name, parameterType, repeatState);
+      _assertNotStringContainer(statePath, parameterType, repeatState);
       const stateArray = Array.isArray(repeatState)
         ? (repeatState as Record<string, unknown>[])
         : [];
@@ -258,7 +258,7 @@ export function walkFormat2State(
       const section = toolInput as SectionParameterModel;
       const sectionState = state[name];
 
-      _assertNotStringContainer(name, parameterType, sectionState);
+      _assertNotStringContainer(statePath, parameterType, sectionState);
       const stateDict = (sectionState as Record<string, unknown>) ?? {};
 
       const innerResult = walkFormat2State(section.parameters, stateDict, leafCallback, statePath);
@@ -291,13 +291,32 @@ export class UnknownKeyError extends Error {
   }
 }
 
-/** Assert that a container parameter value is not a string (legacy encoding). */
-function _assertNotStringContainer(name: string, parameterType: string, value: unknown): void {
-  if (typeof value === "string") {
-    throw new Error(
-      `Container parameter "${name}" (${parameterType}) has string value — ` +
+/**
+ * Error thrown when a container parameter (section/repeat/conditional) is given
+ * a scalar string value instead of the expected nested dict/list — a sign of
+ * legacy parameter encoding the schema-aware walkers don't accept.
+ *
+ * Mirrors {@link UnknownKeyError}: carries the offending parameter's flat state
+ * path and container type as structured fields so callers can map it to a
+ * located diagnostic instead of parsing the message text.
+ */
+export class StringContainerError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly parameterType: string,
+  ) {
+    super(
+      `Container parameter "${path}" (${parameterType}) has string value — ` +
         `expected dict/list. This indicates legacy parameter encoding which is not supported. ` +
         `Decode the workflow first.`,
     );
+    this.name = "StringContainerError";
+  }
+}
+
+/** Assert that a container parameter value is not a string (legacy encoding). */
+function _assertNotStringContainer(path: string, parameterType: string, value: unknown): void {
+  if (typeof value === "string") {
+    throw new StringContainerError(path, parameterType);
   }
 }

--- a/packages/schema/test/stateful-validate.test.ts
+++ b/packages/schema/test/stateful-validate.test.ts
@@ -6,12 +6,27 @@ import {
   ConversionValidationFailure,
   validateNativeStepState,
   validateFormat2StepState,
+  validateFormat2StepStateStrict,
 } from "../src/workflow/stateful-validate.js";
 import type {
   IntegerParameterModel,
+  SectionParameterModel,
   TextParameterModel,
   ToolParameterModel,
 } from "../src/schema/bundle-types.js";
+
+function sectionParam(name: string, parameters: ToolParameterModel[]): SectionParameterModel {
+  return {
+    name,
+    parameter_type: "gx_section",
+    hidden: false,
+    label: null,
+    help: null,
+    argument: null,
+    is_dynamic: false,
+    parameters,
+  };
+}
 
 function intParam(name: string, optional = false): IntegerParameterModel {
   return {
@@ -106,5 +121,18 @@ describe("validateFormat2StepState", () => {
       expect(err).toBeInstanceOf(ConversionValidationFailure);
       expect((err as ConversionValidationFailure).phase).toBe("post");
     }
+  });
+});
+
+describe("validateFormat2StepStateStrict", () => {
+  it("returns a located diagnostic (does not throw) for a scalar in a section", () => {
+    const inputs: ToolParameterModel[] = [sectionParam("advanced", [textParam("opt")])];
+    const diags = validateFormat2StepStateStrict(inputs, { advanced: "not_a_dict" });
+
+    expect(diags).toHaveLength(1);
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].path).toBe("advanced");
+    expect(diags[0].message).toContain("expected a nested object or list");
+    expect(diags[0].message).not.toContain("legacy parameter encoding"); // walker jargon dropped
   });
 });

--- a/packages/schema/test/walker.test.ts
+++ b/packages/schema/test/walker.test.ts
@@ -4,6 +4,7 @@ import {
   walkFormat2State,
   SKIP_VALUE,
   UnknownKeyError,
+  StringContainerError,
 } from "../src/workflow/walker.js";
 import type {
   ToolParameterModel,
@@ -466,6 +467,33 @@ describe("walkNativeState", () => {
       expect(() => walkNativeState({}, [section], state, identity)).toThrow(
         /legacy parameter encoding/,
       );
+    });
+
+    it("throws a typed StringContainerError carrying param path and type", () => {
+      const section = sectionParam("advanced", [textParam("opt")]);
+      const state = { advanced: "oops" };
+      try {
+        walkNativeState({}, [section], state, identity);
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(StringContainerError);
+        const e = err as StringContainerError;
+        expect(e.path).toBe("advanced");
+        expect(e.parameterType).toBe("gx_section");
+      }
+    });
+
+    it("includes the nested prefix in the path for a string container inside a section", () => {
+      const inner = sectionParam("inner", [textParam("opt")]);
+      const outer = sectionParam("outer", [inner]);
+      const state = { outer: { inner: "oops" } };
+      try {
+        walkNativeState({}, [outer], state, identity);
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(StringContainerError);
+        expect((err as StringContainerError).path).toBe("outer|inner");
+      }
     });
   });
 });


### PR DESCRIPTION
## Problem

When a workflow step's tool state puts a scalar where a container parameter (`gx_section` / `gx_repeat` / `gx_conditional`) is expected, the schema-aware walker (`_assertNotStringContainer`) threw a **bare `Error`** whose only structured data lived in the English message:

```
Error: Container parameter "filter_options" (gx_section) has string value — expected dict/list. ...
```

Functions whose contract is to **return** `ToolStateDiagnostic[]` (the LSP-facing validators) let this throw escape, so one malformed step **crashed the entire validation pass** instead of producing a located diagnostic. Downstream (galaxy-workflows-vscode) was forced to regex-match the message text to recover the param name — a brittle coupling to upstream prose.

## Fix

Mirror the existing `UnknownKeyError` pattern:

- **`walker.ts`** — `_assertNotStringContainer` now throws a typed **`StringContainerError`** carrying the offending param's flat state path and container type as structured fields. Exported from the `workflow` barrel (parity with `UnknownKeyError`). Call sites pass the located `statePath` (not just the leaf `name`), so nested containers report e.g. `outer|inner`.
- **`stateful-validate.ts`** — new `stringContainerDiagnostic()` helper maps the error to a located `ToolStateDiagnostic` (normalizing the walker's `|` path separator to `.`). `validateFormat2StepStateStrict` catches it and returns the diagnostic instead of throwing.
- **`tool-state-validator.ts`** — `ToolStateValidator.validateNativeStep` / `validateFormat2Step` catch it alongside the existing `ConversionValidationFailure` handling.

Conversion paths (`clean`, stateful convert, CLI `validate-workflow`, `gxwf-web`) still throw — and the **error message is unchanged**, so existing `message.includes("legacy parameter encoding")` consumers keep working.

## Why upstream

The walker and the validation contract both live here; a walker throw escaping a "returns diagnostics" function is an upstream contract bug, and there were already two precedents for the right shape (`UnknownKeyError` typed class, `ConversionValidationFailure` caught→mapped). Fixing it here means every consumer benefits and downstream can drop its message-regex workaround.

## Tests

- `walker.test.ts`: asserts the typed `StringContainerError` with `path`/`parameterType`, including nested-prefix path. Existing `/legacy parameter encoding/` throw tests still pass (message preserved).
- `stateful-validate.test.ts`: `validateFormat2StepStateStrict` returns a located diagnostic (no throw) for a scalar in a section.
- Full suite green: schema 4932 passing, repo-wide typecheck + cli/gxwf-web/gxwf-client/gxwf-ui/integration tests all pass, lint clean.

Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)