### PR TITLE
fix(toNative): omit tool_uuid on shed tool steps

### DIFF
--- a/.changeset/fix-shed-tool-uuid.md
+++ b/.changeset/fix-shed-tool-uuid.md
@@ -1,0 +1,15 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+fix(toNative): stop emitting the workflow step uuid as `tool_uuid` on shed tool steps
+
+`toNative` was assigning each shed tool step's workflow `uuid` to `tool_uuid`.
+`tool_uuid` is a reference to a dynamic / inline-defined (user) tool, not a
+workflow-step identifier, so Galaxy's importer tried to resolve a tool by that
+uuid and aborted the whole import with `ObjectNotFound`. Every multi-shed-tool
+workflow produced by `gxwf convert --to native` was un-importable.
+
+`tool_uuid` is now omitted entirely for shed tools, and on the user-defined
+branch carries the tool representation's `uuid` (or `null` when none is
+provided). The step `uuid` is still emitted unchanged. Fixes #147.

--- a/packages/schema/src/workflow/normalized/toNative.ts
+++ b/packages/schema/src/workflow/normalized/toNative.ts
@@ -378,7 +378,9 @@ function _buildToolStep(
     tool_state: toolState,
     tool_representation: toolRepresentation,
     in: _extractStepInDefaults(step),
-    tool_uuid: isUserDefinedTool ? null : (step.uuid ?? undefined),
+    tool_uuid: isUserDefinedTool
+      ? ((toolRepresentation?.uuid as string | undefined) ?? null)
+      : undefined,
     input_connections: inputConnections,
     post_job_actions: postJobActions,
     position: _defaultPosition(step.position, orderIndex),

--- a/packages/schema/test/to-native-tool-uuid.test.ts
+++ b/packages/schema/test/to-native-tool-uuid.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression tests for tool_uuid emission in toNative (issue #147).
+ *
+ * tool_uuid is a reference to a dynamic / inline-defined (user) tool, not a
+ * workflow-step identifier. Shed tools must NOT carry the step uuid as their
+ * tool_uuid — Galaxy's importer would try to resolve a tool by that uuid and
+ * abort the whole import with ObjectNotFound.
+ */
+
+import { describe, it, expect } from "vitest";
+import { toNative } from "../src/workflow/index.js";
+
+const STEP_UUID = "29d53567-67bd-4c7b-8fa6-abc8282e6a9f";
+
+describe("toNative tool_uuid", () => {
+  it("does not copy the step uuid onto a shed tool's tool_uuid", () => {
+    const native = toNative({
+      class: "GalaxyWorkflow",
+      inputs: { the_input: "data" },
+      outputs: {},
+      steps: {
+        cat: {
+          tool_id: "toolshed.g2.bx.psu.edu/repos/devteam/cat/cat1/1.0.0",
+          tool_version: "1.0.0",
+          uuid: STEP_UUID,
+          in: { input1: "the_input" },
+        },
+      },
+    });
+
+    const step = native.steps["1"];
+    expect(step.type).toBe("tool");
+    // step identity is preserved on uuid...
+    expect(step.uuid).toBe(STEP_UUID);
+    // ...but a shed tool carries no tool_uuid at all (not the step uuid).
+    expect(step.tool_uuid).toBeUndefined();
+  });
+
+  it("emits null tool_uuid for an inline user-defined tool without a uuid", () => {
+    const native = toNative({
+      class: "GalaxyWorkflow",
+      inputs: { the_input: "data" },
+      outputs: {},
+      steps: {
+        my_tool: {
+          run: {
+            class: "GalaxyUserTool",
+            id: "cat_user_defined",
+            version: "0.1",
+            name: "cat_user_defined",
+            container: "busybox",
+            shell_command: "cat '$(inputs.input1.path)' > output.txt",
+            inputs: [{ name: "input1", type: "data" }],
+            outputs: [{ name: "output1", type: "data", from_work_dir: "output.txt" }],
+          },
+          in: { input1: "the_input" },
+        },
+      },
+    });
+
+    const step = native.steps["1"];
+    expect(step.tool_id).toBeNull();
+    expect((step.tool_representation as Record<string, unknown>).class).toBe("GalaxyUserTool");
+    expect(step.tool_uuid).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #147.

## Problem

`gxwf convert --to native` emitted a `tool_uuid` equal to the workflow **step** `uuid` on every **Tool Shed** tool step. Galaxy's importer treats `tool_uuid` as an embedded/user-defined-tool reference, tries to resolve a tool by that uuid, and aborts the whole import:

```
galaxy.exceptions.ObjectNotFound: Failed to find a tool with uuid [29d53567-...]
```

Every multi-shed-tool workflow produced by `convert --to native` was un-importable.

## Root cause

`packages/schema/src/workflow/normalized/toNative.ts` had:

```ts
tool_uuid: isUserDefinedTool ? null : (step.uuid ?? undefined),
```

For a shed tool (`isUserDefinedTool === false`) this assigned the workflow step's `uuid` to `tool_uuid` — a field that semantically references a dynamic/inline-defined tool's identity, not a workflow step.

## Fix

```ts
tool_uuid: isUserDefinedTool
  ? ((toolRepresentation?.uuid as string | undefined) ?? null)
  : undefined,
```

- **Shed tools** → `tool_uuid` omitted entirely (Galaxy treats absent and null identically). This matches the gxformat2 Python reference, whose `_conversion.py` never sets `tool_uuid` when building a native step from format2.
- **Inline user-defined tools** → carry the tool representation's `uuid`, or `null` (keeps the synced `to_native.yml` golden, which expects `tool_uuid: null`).
- Step `uuid` is emitted unchanged.

## Tests

New regression test `packages/schema/test/to-native-tool-uuid.test.ts`:
- shed step's `tool_uuid` is omitted (not the step uuid), step `uuid` preserved
- inline user-defined tool emits `tool_uuid: null`

Full `make test` (4964 schema tests + all packages) and `make check` green. Patch changeset for `@galaxy-tool-util/schema` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)