### PR TITLE
feat(validate): fetch uncached tools during tool-state validation (default on)

### DIFF
--- a/.changeset/validate-fetch-uncached-tools.md
+++ b/.changeset/validate-fetch-uncached-tools.md
@@ -1,0 +1,29 @@
+---
+"@galaxy-tool-util/cli": minor
+"@galaxy-tool-util/core": minor
+---
+
+feat(validate): fetch uncached tools during tool-state validation (default on)
+
+`gxwf validate` and `gxwf draft-validate --concrete` previously read only the
+local tool cache: any tool not already added via `galaxy-tool-cache add` was
+reported `skipped — not in cache`, so its `tool_state` went unchecked. They now
+fetch missing tools from the ToolShed (and an optional `--galaxy-url` Galaxy
+instance) on a cache miss, cache them, and validate against the real tool — so a
+fresh cache validates every step instead of silently skipping.
+
+Pass `--offline` to keep the old behavior (read-only cache; uncached tools are
+skipped). `--galaxy-url <url>` adds a Galaxy instance as a fallback source after
+the ToolShed.
+
+The lower-level `validateNativeSteps` / `validateFormat2Steps` stay offline by
+default — fetching only happens when an explicit `ToolInfoService` is supplied —
+so callers that pass only a cache are unaffected.
+
+Core gains two methods that keep cache-key derivation in one place:
+`ToolInfoService.resolveTool(toolId, version)` returns the fetched tool together
+with the authoritative cache key it was stored under (`getToolInfo` is now a thin
+projection of it), and `ToolCache.loadByToolId(toolId, version)` is the canonical
+network-free "is this cached?" read. The CLI tool resolver consumes these instead
+of re-deriving keys, so an online fetch can no longer return a key that points at
+a different cache entry than the one written.

--- a/docs/skills/gxwf-cli/SKILL.md
+++ b/docs/skills/gxwf-cli/SKILL.md
@@ -25,6 +25,8 @@ Validate Galaxy workflow files (structure + optional tool state)
 | `--format <fmt>` | Force format: native or format2 (auto-detected by default) |
 | `--no-tool-state` | Skip tool state validation |
 | `--cache-dir <dir>` | Tool cache directory |
+| `--offline` | Do not fetch uncached tools; read only the local cache (uncached tools are skipped) |
+| `--galaxy-url <url>` | Galaxy instance to try as a tool source after the ToolShed when fetching uncached tools |
 | `--mode <mode>` | Validation backend: effect (default) or json-schema (default: `effect`) |
 | `--tool-schema-dir <dir>` | Directory of pre-exported per-tool JSON Schemas (for offline json-schema mode) |
 | `--json` | Output structured JSON report |
@@ -64,6 +66,8 @@ Validate a draft Galaxy workflow (class: GalaxyWorkflowDraft)
 | `--report-markdown [file]` | Write Markdown report to file (or stdout if omitted) |
 | `--concrete` | Additionally extract the concrete subset and run the regular `gxwf validate` checks on it |
 | `--cache-dir <dir>` | Tool cache directory (for --concrete tool-state validation) |
+| `--offline` | Do not fetch uncached tools; read only the local cache (uncached tools are skipped) |
+| `--galaxy-url <url>` | Galaxy instance to try as a tool source after the ToolShed when fetching uncached tools |
 | `--no-tool-state` | Skip tool-state validation in the --concrete pass (default: enabled when --concrete is set) |
 | `--connections` | Validate connection-type compatibility on the --concrete subset (collection algebra, map-over) |
 | `--strict` | Shorthand for --strict-structure --strict-encoding --strict-state |

--- a/packages/cli/spec/gxwf.json
+++ b/packages/cli/spec/gxwf.json
@@ -47,6 +47,14 @@
           "description": "Tool cache directory"
         },
         {
+          "flags": "--offline",
+          "description": "Do not fetch uncached tools; read only the local cache (uncached tools are skipped)"
+        },
+        {
+          "flags": "--galaxy-url <url>",
+          "description": "Galaxy instance to try as a tool source after the ToolShed when fetching uncached tools"
+        },
+        {
           "flags": "--mode <mode>",
           "description": "Validation backend: effect (default) or json-schema",
           "default": "effect"
@@ -125,6 +133,14 @@
         {
           "flags": "--cache-dir <dir>",
           "description": "Tool cache directory (for --concrete tool-state validation)"
+        },
+        {
+          "flags": "--offline",
+          "description": "Do not fetch uncached tools; read only the local cache (uncached tools are skipped)"
+        },
+        {
+          "flags": "--galaxy-url <url>",
+          "description": "Galaxy instance to try as a tool source after the ToolShed when fetching uncached tools"
         },
         {
           "flags": "--no-tool-state",

--- a/packages/cli/src/commands/annotate-connections.ts
+++ b/packages/cli/src/commands/annotate-connections.ts
@@ -16,7 +16,7 @@ import { makeNodeToolCache } from "@galaxy-tool-util/core/node";
 import type { ParsedTool } from "@galaxy-tool-util/schema";
 
 import { buildGetToolInfo } from "./connection-validation.js";
-import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+import { isResolveError, resolveTool } from "./resolve-tool.js";
 
 export interface ResolveEdgeAnnotationsOptions {
   cacheDir?: string;
@@ -63,7 +63,7 @@ export async function resolveEdgeAnnotationsAndSpecsWithCache(
 }> {
   const specs = new Map<string, ResolvedToolSpec>();
   const getToolInfo = await _buildGetToolInfo(data, async (id, version) => {
-    const r = await loadCachedTool(cache, id, version);
+    const r = await resolveTool(cache, id, version);
     if (isResolveError(r)) return null;
     const ver = r.tool.version ?? version ?? "";
     specs.set(`${id}@${ver}`, { tool_id: id, tool_version: ver, parsed: r.tool });

--- a/packages/cli/src/commands/connection-validation.ts
+++ b/packages/cli/src/commands/connection-validation.ts
@@ -20,7 +20,7 @@ import {
 import type { ToolCache } from "@galaxy-tool-util/core";
 import type { ConnectionValidationReport } from "@galaxy-tool-util/schema";
 
-import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+import { isResolveError, resolveTool } from "./resolve-tool.js";
 
 export { collectToolRefs };
 export type { ToolRef } from "@galaxy-tool-util/connection-validation";
@@ -38,7 +38,7 @@ export async function buildGetToolInfo(
   cache: ToolCache,
 ): Promise<GetToolInfo> {
   return _buildGetToolInfo(data, async (id, version) => {
-    const r = await loadCachedTool(cache, id, version);
+    const r = await resolveTool(cache, id, version);
     return isResolveError(r) ? null : r.tool;
   });
 }

--- a/packages/cli/src/commands/draft-validate.ts
+++ b/packages/cli/src/commands/draft-validate.ts
@@ -33,7 +33,6 @@
  *       (class !== GalaxyWorkflowDraft, schema decode error)
  */
 import { dirname } from "node:path";
-import { makeNodeToolCache } from "@galaxy-tool-util/core/node";
 import {
   buildSingleDraftValidationReport,
   checkStrictEncoding,
@@ -51,6 +50,7 @@ import {
   type ValidationStepResult,
 } from "@galaxy-tool-util/schema";
 import { decodeStructureErrors, validateFormat2Steps } from "./validate-workflow.js";
+import { makeValidationResolver } from "./resolve-tool.js";
 import { readWorkflowFile } from "./workflow-io.js";
 import { findStdoutSinkConflict, writeReportHtml, writeReportOutput } from "./report-output.js";
 import { resolveStrictOptions, type StrictOptions } from "./strict-options.js";
@@ -64,6 +64,8 @@ export interface DraftValidateOptions extends StrictOptions {
   reportMarkdown?: string | boolean;
   concrete?: boolean;
   cacheDir?: string;
+  offline?: boolean;
+  galaxyUrl?: string;
   toolState?: boolean;
   connections?: boolean;
 }
@@ -190,12 +192,12 @@ async function runConcretePass(
   // Tool-state defaults to ON (matches `gxwf validate`); --no-tool-state opts out.
   const toolStateEnabled = opts.toolState !== false;
   if (toolStateEnabled) {
-    const cache = makeNodeToolCache({ cacheDir: opts.cacheDir });
+    const { cache, service } = makeValidationResolver(opts);
     await cache.index.load();
     const expansionOpts: ExpansionOptions = {
       resolver: createDefaultResolver({ workflowDirectory: dirname(filePath) }),
     };
-    const stepResults = await validateFormat2Steps(trimmed, cache, "", expansionOpts);
+    const stepResults = await validateFormat2Steps(trimmed, cache, "", expansionOpts, service);
     report.tool_state = {
       results: stepResults,
       summary: summarize(stepResults),
@@ -212,7 +214,7 @@ async function runConcretePass(
     }
   } else if (opts.connections) {
     // --connections without tool-state still needs a cache to look up tools.
-    const cache = makeNodeToolCache({ cacheDir: opts.cacheDir });
+    const { cache } = makeValidationResolver(opts);
     await cache.index.load();
     report.connection_report = await buildConnectionReport(trimmed, cache);
   }

--- a/packages/cli/src/commands/resolve-tool.ts
+++ b/packages/cli/src/commands/resolve-tool.ts
@@ -1,4 +1,5 @@
-import { type ToolCache, cacheKey } from "@galaxy-tool-util/core";
+import { type ToolCache, type ToolInfoService, cacheKey } from "@galaxy-tool-util/core";
+import { makeNodeToolCache, makeNodeToolInfoService } from "@galaxy-tool-util/core/node";
 import type { ParsedTool } from "@galaxy-tool-util/schema";
 
 export interface ResolvedTool {
@@ -8,25 +9,79 @@ export interface ResolvedTool {
 
 export type ResolveError =
   | { kind: "no_version"; toolId: string }
-  | { kind: "not_cached"; toolId: string; key: string };
+  | { kind: "not_cached"; toolId: string; key: string; fetchAttempted?: boolean };
 
 export function isResolveError(r: ResolvedTool | ResolveError): r is ResolveError {
   return "kind" in r;
 }
 
-export async function loadCachedTool(
+/** Human-readable reason a tool failed to resolve, for skip messages. */
+export function describeResolveError(err: ResolveError): string {
+  if (err.kind === "no_version") return `no version for ${err.toolId}`;
+  return err.fetchAttempted
+    ? `${err.toolId} not in cache (fetch failed)`
+    : `${err.toolId} not in cache`;
+}
+
+/**
+ * Resolve a tool to its parsed metadata and cache key. With a fetch `service`,
+ * the service reads the cache and fetches+caches on miss (it owns the key).
+ * Without a service, performs a network-free cache read. The passed `cache` is
+ * only consulted in the offline branch — online, the service's own cache is
+ * authoritative, so the two can never diverge.
+ */
+export async function resolveTool(
   cache: ToolCache,
   toolId: string,
   version?: string | null,
+  service?: ToolInfoService,
 ): Promise<ResolvedTool | ResolveError> {
+  if (service) {
+    const resolved = await service.resolveTool(toolId, version ?? null);
+    if (resolved !== null) return resolved;
+    return notCached(cache, toolId, version, true);
+  }
+  const hit = await cache.loadByToolId(toolId, version ?? null);
+  if (hit !== null) return hit;
+  return notCached(cache, toolId, version, false);
+}
+
+async function notCached(
+  cache: ToolCache,
+  toolId: string,
+  version: string | null | undefined,
+  fetchAttempted: boolean,
+): Promise<ResolveError> {
   const coords = cache.resolveToolCoordinates(toolId, version);
-  if (coords.version === null) {
-    return { kind: "no_version", toolId };
-  }
+  if (coords.version === null) return { kind: "no_version", toolId };
   const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, coords.version);
-  const tool = await cache.loadCached(key);
-  if (tool === null) {
-    return { kind: "not_cached", toolId, key };
+  return { kind: "not_cached", toolId, key, fetchAttempted };
+}
+
+/** Options shared by validation commands for resolving (and optionally fetching) tools. */
+export interface ValidationFetchOptions {
+  cacheDir?: string;
+  /** Skip the network: read only the local cache (uncached tools are skipped). */
+  offline?: boolean;
+  /** Extra Galaxy instance tried as a tool source after the ToolShed. */
+  galaxyUrl?: string;
+}
+
+export interface ValidationResolver {
+  cache: ToolCache;
+  /** Present unless `offline` — fetches and caches tools missing locally. */
+  service?: ToolInfoService;
+}
+
+/**
+ * Build the cache (and, unless `offline`, the fetch service) for tool-state
+ * validation. When fetching is on, validation reads `service.cache` so freshly
+ * fetched tools are visible without a disk round-trip.
+ */
+export function makeValidationResolver(opts: ValidationFetchOptions): ValidationResolver {
+  if (opts.offline) {
+    return { cache: makeNodeToolCache({ cacheDir: opts.cacheDir }) };
   }
-  return { tool, key };
+  const service = makeNodeToolInfoService({ cacheDir: opts.cacheDir, galaxyUrl: opts.galaxyUrl });
+  return { cache: service.cache, service };
 }

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -7,7 +7,7 @@ import {
 } from "@galaxy-tool-util/schema";
 import * as JSONSchema from "effect/JSONSchema";
 import { writeFile } from "node:fs/promises";
-import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+import { isResolveError, resolveTool } from "./resolve-tool.js";
 
 export interface SchemaOptions {
   toolVersion?: string;
@@ -29,7 +29,7 @@ export async function runSchema(toolId: string, opts: SchemaOptions): Promise<vo
 
   const cache = makeNodeToolCache({ cacheDir: opts.cacheDir });
   await cache.index.load();
-  const result = await loadCachedTool(cache, toolId, opts.toolVersion);
+  const result = await resolveTool(cache, toolId, opts.toolVersion);
   if (isResolveError(result)) {
     if (result.kind === "no_version") {
       console.error(`No version specified for tool: ${toolId}`);

--- a/packages/cli/src/commands/stateful-tool-inputs.ts
+++ b/packages/cli/src/commands/stateful-tool-inputs.ts
@@ -25,7 +25,7 @@ import {
   type ToolParameterBundleModel,
   type WorkflowFormat,
 } from "@galaxy-tool-util/schema";
-import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+import { isResolveError, resolveTool } from "./resolve-tool.js";
 
 type ToolInputs = ToolParameterBundleModel["parameters"];
 
@@ -67,7 +67,7 @@ export async function loadToolInputsForWorkflow(
   for (const [toolId, version] of refs) {
     const key = toolKey(toolId, version);
     if (loaded.has(key)) continue;
-    const resolved = await loadCachedTool(cache, toolId, version);
+    const resolved = await resolveTool(cache, toolId, version);
     if (isResolveError(resolved)) {
       const reason =
         resolved.kind === "no_version" ? `no version for ${toolId}` : `${toolId} not in cache`;

--- a/packages/cli/src/commands/summarize.ts
+++ b/packages/cli/src/commands/summarize.ts
@@ -8,7 +8,7 @@ import {
   type ToolParameterBundleModel,
 } from "@galaxy-tool-util/schema";
 import * as JSONSchema from "effect/JSONSchema";
-import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+import { isResolveError, resolveTool } from "./resolve-tool.js";
 
 export interface SummarizeOptions {
   toolVersion?: string;
@@ -75,7 +75,7 @@ export async function buildToolSummaryManifest(
   const cacheDir = getCacheDir(opts.cacheDir);
   const cache = makeNodeToolCache({ cacheDir });
   await cache.index.load();
-  const result = await loadCachedTool(cache, toolId, opts.toolVersion);
+  const result = await resolveTool(cache, toolId, opts.toolVersion);
   if (isResolveError(result)) {
     if (result.kind === "no_version") {
       console.error(`No version specified for tool: ${toolId}`);

--- a/packages/cli/src/commands/validate-workflow-json-schema.ts
+++ b/packages/cli/src/commands/validate-workflow-json-schema.ts
@@ -43,7 +43,7 @@ import type {
   StepValidationResult,
 } from "./validate-workflow.js";
 import { isEmptyState } from "./validate-workflow.js";
-import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+import { isResolveError, resolveTool } from "./resolve-tool.js";
 
 const Ajv = (Ajv2020 as any).default ?? Ajv2020;
 
@@ -383,7 +383,7 @@ async function _validateNativeStepJsonSchema(
   cache: ToolCache,
   toolSchemaDir?: string,
 ): Promise<StepValidationResult> {
-  const resolved = await loadCachedTool(cache, toolId, toolVersion);
+  const resolved = await resolveTool(cache, toolId, toolVersion);
   if (isResolveError(resolved)) {
     const reason =
       resolved.kind === "no_version" ? `no version for ${toolId}` : `${toolId} not in cache`;
@@ -538,7 +538,7 @@ async function _validateFormat2StepJsonSchema(
   cache: ToolCache,
   toolSchemaDir?: string,
 ): Promise<StepValidationResult> {
-  const resolved = await loadCachedTool(cache, toolId, toolVersion);
+  const resolved = await resolveTool(cache, toolId, toolVersion);
   if (isResolveError(resolved)) {
     const reason =
       resolved.kind === "no_version" ? `no version for ${toolId}` : `${toolId} not in cache`;

--- a/packages/cli/src/commands/validate-workflow.ts
+++ b/packages/cli/src/commands/validate-workflow.ts
@@ -1,5 +1,4 @@
-import type { ToolCache } from "@galaxy-tool-util/core";
-import { makeNodeToolCache } from "@galaxy-tool-util/core/node";
+import type { ToolCache, ToolInfoService } from "@galaxy-tool-util/core";
 import {
   createFieldModel,
   GalaxyWorkflowSchema,
@@ -26,7 +25,12 @@ import {
 import * as ParseResult from "effect/ParseResult";
 import * as S from "effect/Schema";
 import { dirname } from "node:path";
-import { isResolveError, loadCachedTool } from "./resolve-tool.js";
+import {
+  isResolveError,
+  resolveTool,
+  describeResolveError,
+  makeValidationResolver,
+} from "./resolve-tool.js";
 import { createDefaultResolver } from "./url-resolver.js";
 import { renderStepResults } from "./render-results.js";
 import { readWorkflowFile, resolveFormat } from "./workflow-io.js";
@@ -43,6 +47,8 @@ export interface ValidateWorkflowOptions extends StrictOptions {
   format?: string;
   toolState?: boolean;
   cacheDir?: string;
+  offline?: boolean;
+  galaxyUrl?: string;
   mode?: ValidationMode;
   toolSchemaDir?: string;
   json?: boolean;
@@ -168,7 +174,7 @@ export async function runValidateWorkflow(
     return;
   }
 
-  const cache = makeNodeToolCache({ cacheDir: opts.cacheDir });
+  const { cache, service } = makeValidationResolver(opts);
   await cache.index.load();
 
   let results: StepValidationResult[] = [];
@@ -176,9 +182,9 @@ export async function runValidateWorkflow(
 
   try {
     if (format === "native") {
-      results = await validateNativeSteps(data, cache, "", expansionOpts);
+      results = await validateNativeSteps(data, cache, "", expansionOpts, service);
     } else {
-      results = await validateFormat2Steps(data, cache, "", expansionOpts);
+      results = await validateFormat2Steps(data, cache, "", expansionOpts, service);
     }
   } catch (error) {
     // Catch legacy encoding errors thrown by walker and capture them
@@ -263,15 +269,17 @@ export async function validateNativeSteps(
   cache: ToolCache,
   prefix = "",
   expansionOpts?: ExpansionOptions,
+  service?: ToolInfoService,
 ): Promise<StepValidationResult[]> {
   const expanded = await expandedNative(data, expansionOpts);
-  return _validateNativeWorkflow(expanded, cache, prefix);
+  return _validateNativeWorkflow(expanded, cache, prefix, service);
 }
 
 async function _validateNativeWorkflow(
   wf: NormalizedNativeWorkflow,
   cache: ToolCache,
   prefix: string,
+  service?: ToolInfoService,
 ): Promise<StepValidationResult[]> {
   const results: StepValidationResult[] = [];
 
@@ -280,7 +288,12 @@ async function _validateNativeWorkflow(
 
     // Recurse into subworkflows
     if (step.type === "subworkflow" && step.subworkflow) {
-      const subResults = await _validateNativeWorkflow(step.subworkflow, cache, `${stepLabel}.`);
+      const subResults = await _validateNativeWorkflow(
+        step.subworkflow,
+        cache,
+        `${stepLabel}.`,
+        service,
+      );
       results.push(...subResults);
       continue;
     }
@@ -289,7 +302,7 @@ async function _validateNativeWorkflow(
     if (!toolId) continue;
     const toolVersion = step.tool_version ?? null;
 
-    const result = await _validateNativeStep(step, stepLabel, toolId, toolVersion, cache);
+    const result = await _validateNativeStep(step, stepLabel, toolId, toolVersion, cache, service);
     results.push(result);
   }
 
@@ -302,11 +315,11 @@ async function _validateNativeStep(
   toolId: string,
   toolVersion: string | null,
   cache: ToolCache,
+  service?: ToolInfoService,
 ): Promise<StepValidationResult> {
-  const resolved = await loadCachedTool(cache, toolId, toolVersion);
+  const resolved = await resolveTool(cache, toolId, toolVersion, service);
   if (isResolveError(resolved)) {
-    const reason =
-      resolved.kind === "no_version" ? `no version for ${toolId}` : `${toolId} not in cache`;
+    const reason = describeResolveError(resolved);
     return {
       step: stepLabel,
       tool_id: toolId,
@@ -401,15 +414,17 @@ export async function validateFormat2Steps(
   cache: ToolCache,
   prefix = "",
   expansionOpts?: ExpansionOptions,
+  service?: ToolInfoService,
 ): Promise<StepValidationResult[]> {
   const expanded = await expandedFormat2(data, expansionOpts);
-  return _validateFormat2Workflow(expanded, cache, prefix);
+  return _validateFormat2Workflow(expanded, cache, prefix, service);
 }
 
 async function _validateFormat2Workflow(
   wf: NormalizedFormat2Workflow,
   cache: ToolCache,
   prefix: string,
+  service?: ToolInfoService,
 ): Promise<StepValidationResult[]> {
   const results: StepValidationResult[] = [];
 
@@ -423,6 +438,7 @@ async function _validateFormat2Workflow(
         step.run as NormalizedFormat2Workflow,
         cache,
         `${stepLabel}.`,
+        service,
       );
       results.push(...subResults);
       continue;
@@ -432,7 +448,7 @@ async function _validateFormat2Workflow(
     if (!toolId) continue;
     const toolVersion = step.tool_version ?? null;
 
-    const result = await _validateFormat2Step(step, stepLabel, toolId, toolVersion, cache);
+    const result = await _validateFormat2Step(step, stepLabel, toolId, toolVersion, cache, service);
     results.push(result);
   }
 
@@ -445,11 +461,11 @@ async function _validateFormat2Step(
   toolId: string,
   toolVersion: string | null,
   cache: ToolCache,
+  service?: ToolInfoService,
 ): Promise<StepValidationResult> {
-  const resolved = await loadCachedTool(cache, toolId, toolVersion);
+  const resolved = await resolveTool(cache, toolId, toolVersion, service);
   if (isResolveError(resolved)) {
-    const reason =
-      resolved.kind === "no_version" ? `no version for ${toolId}` : `${toolId} not in cache`;
+    const reason = describeResolveError(resolved);
     return {
       step: stepLabel,
       tool_id: toolId,
@@ -607,7 +623,7 @@ async function _detectNativeEncodingErrors(
     const toolId = step.tool_id;
     if (!toolId) continue;
 
-    const resolved = await loadCachedTool(cache, toolId, step.tool_version ?? null);
+    const resolved = await resolveTool(cache, toolId, step.tool_version ?? null);
     if (isResolveError(resolved)) continue;
 
     const inputs = resolved.tool.inputs as ToolParameterBundleModel["parameters"];

--- a/packages/cli/test/annotate-connections.parity.test.ts
+++ b/packages/cli/test/annotate-connections.parity.test.ts
@@ -1,7 +1,7 @@
 /**
  * Parity coverage for the lifted preloader. `resolveEdgeAnnotationsWithCache`
  * goes through `@galaxy-tool-util/connection-validation::buildGetToolInfo` via
- * the CLI's `loadCachedTool` adapter — this asserts the wired path produces
+ * the CLI's `resolveTool` adapter — this asserts the wired path produces
  * the EdgeAnnotation map we expect for a workflow with a known data edge.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";

--- a/packages/cli/test/draft-validate.test.ts
+++ b/packages/cli/test/draft-validate.test.ts
@@ -447,11 +447,12 @@ steps:
 `;
     const wfPath = join(ctx.tmpDir, "with-toolstate.gxwf.yml");
     await writeFile(wfPath, wf);
-    // Point at an empty cache dir so we exercise the tool-state loop without
-    // depending on a particular tool being cached locally.
+    // Point at an empty cache dir and stay offline so we exercise the tool-state
+    // loop without depending on a particular tool being cached or fetchable.
     await runDraftValidate(wfPath, {
       json: true,
       concrete: true,
+      offline: true,
       cacheDir: join(ctx.tmpDir, "empty-cache"),
     });
 
@@ -487,6 +488,7 @@ steps:
       json: true,
       concrete: true,
       strictState: true,
+      offline: true,
       cacheDir: join(ctx.tmpDir, "empty-cache"),
     });
 

--- a/packages/cli/test/resolve-tool.test.ts
+++ b/packages/cli/test/resolve-tool.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { makeNodeToolCache, makeNodeToolInfoService } from "@galaxy-tool-util/core/node";
+import { isResolveError, resolveTool } from "../src/commands/resolve-tool.js";
+import { textOnlyTool } from "./helpers/fixtures.js";
+
+const TOOL_ID = "toolshed.g2.bx.psu.edu/repos/test/fetched/fetched_tool";
+
+function toolResponse(): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(textOnlyTool), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+}
+
+describe("resolveTool", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "resolve-tool-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  it("returns a not_cached error (fetchAttempted=false) when no service is supplied", async () => {
+    const cache = makeNodeToolCache({ cacheDir: tmpDir });
+    const result = await resolveTool(cache, TOOL_ID, "1.0");
+    expect(isResolveError(result)).toBe(true);
+    if (isResolveError(result)) {
+      expect(result.kind).toBe("not_cached");
+      if (result.kind === "not_cached") expect(result.fetchAttempted).toBe(false);
+    }
+  });
+
+  it("fetches the tool on a cache miss when a service is supplied", async () => {
+    let calls = 0;
+    const service = makeNodeToolInfoService({
+      cacheDir: tmpDir,
+      fetcher: (async (...args) => {
+        calls++;
+        return toolResponse()(...args);
+      }) as typeof fetch,
+    });
+
+    const result = await resolveTool(service.cache, TOOL_ID, "1.0", service);
+    expect(isResolveError(result)).toBe(false);
+    if (!isResolveError(result)) {
+      expect(result.tool.name).toBe("Simple Tool");
+      // The returned key must be the authoritative one the tool was cached
+      // under — loadable straight back, not a re-derived guess.
+      const roundTrip = await service.cache.loadCached(result.key);
+      expect(roundTrip?.name).toBe("Simple Tool");
+    }
+    expect(calls).toBe(1);
+
+    // Second resolve hits the now-warm cache — no extra fetch.
+    const again = await resolveTool(service.cache, TOOL_ID, "1.0", service);
+    expect(isResolveError(again)).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it("reports fetchAttempted=true when a supplied service cannot fetch the tool", async () => {
+    const service = makeNodeToolInfoService({
+      cacheDir: tmpDir,
+      fetcher: (async () => new Response("nope", { status: 404 })) as typeof fetch,
+    });
+
+    const result = await resolveTool(service.cache, TOOL_ID, "1.0", service);
+    expect(isResolveError(result)).toBe(true);
+    if (isResolveError(result) && result.kind === "not_cached") {
+      expect(result.fetchAttempted).toBe(true);
+    }
+  });
+});

--- a/packages/cli/test/strict-validate.test.ts
+++ b/packages/cli/test/strict-validate.test.ts
@@ -162,7 +162,7 @@ describe("validate --strict-state", () => {
     };
     const wfPath = join(ctx.tmpDir, "missing.ga");
     await writeFile(wfPath, JSON.stringify(workflow));
-    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictState: true });
+    await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, strictState: true, offline: true });
 
     expect(process.exitCode).toBe(2);
     const errors = ctx.errSpy.mock.calls.map((c) => c[0]).join("\n");

--- a/packages/cli/test/validate-workflow.test.ts
+++ b/packages/cli/test/validate-workflow.test.ts
@@ -6,7 +6,13 @@ import * as YAML from "yaml";
 import { runValidateWorkflow } from "../src/commands/validate-workflow.js";
 import type { SingleValidationReport } from "@galaxy-tool-util/schema";
 import { createCliTestContext, type CliTestContext } from "./helpers/cli-test-context.js";
-import { seedAllTools, SIMPLE_TOOL_ID, DATA_TOOL_ID, COND_TOOL_ID } from "./helpers/fixtures.js";
+import {
+  seedAllTools,
+  textOnlyTool,
+  SIMPLE_TOOL_ID,
+  DATA_TOOL_ID,
+  COND_TOOL_ID,
+} from "./helpers/fixtures.js";
 
 describe("validate-workflow (connection-aware)", () => {
   let ctx: CliTestContext;
@@ -369,7 +375,7 @@ describe("validate-workflow (connection-aware)", () => {
       };
       const wfPath = join(ctx.tmpDir, "missing.ga");
       await writeFile(wfPath, JSON.stringify(workflow));
-      await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir });
+      await runValidateWorkflow(wfPath, { cacheDir: ctx.tmpDir, offline: true });
 
       const output = ctx.warnSpy.mock.calls.map((c) => c[0]).join("\n");
       expect(output).toContain("skipped");
@@ -598,6 +604,92 @@ describe("validate-workflow (connection-aware)", () => {
       expect(report.encoding_errors.length).toBeGreaterThan(0);
       expect(report.encoding_errors[0]).toContain("legacy parameter encoding");
       expect(report.encoding_errors[0]).toContain("mode");
+    });
+  });
+
+  describe("tool fetching (default online, --offline opts out)", () => {
+    let originalFetch: typeof fetch;
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    // A tool the seeded cache never holds → resolved only by fetching.
+    const FETCH_TOOL_ID = "toolshed.g2.bx.psu.edu/repos/test/fetched/fetched_tool";
+    function fetchToolWorkflow() {
+      return {
+        a_galaxy_workflow: "true",
+        "format-version": "0.1",
+        steps: {
+          "0": {
+            id: 0,
+            type: "tool",
+            label: "Fetched",
+            tool_id: FETCH_TOOL_ID,
+            tool_version: "1.0",
+            tool_state: JSON.stringify({ input_text: "hi" }),
+            input_connections: {},
+          },
+        },
+      };
+    }
+    function parse(): SingleValidationReport {
+      return JSON.parse(ctx.logSpy.mock.calls.map((c) => c[0]).join("\n"));
+    }
+
+    it("fetches an uncached tool from the ToolShed and validates it", async () => {
+      let calls = 0;
+      let requested = "";
+      globalThis.fetch = (async (url: string | URL) => {
+        calls++;
+        requested = String(url);
+        return new Response(JSON.stringify(textOnlyTool), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }) as typeof fetch;
+
+      const wfPath = join(ctx.tmpDir, "fetched.ga");
+      await writeFile(wfPath, JSON.stringify(fetchToolWorkflow()));
+      await runValidateWorkflow(wfPath, { json: true, cacheDir: join(ctx.tmpDir, "empty") });
+
+      const report = parse();
+      expect(calls).toBeGreaterThan(0);
+      expect(requested).toContain("/api/tools/test~fetched~fetched_tool/versions/1.0");
+      expect(report.results[0].status).toBe("ok");
+    });
+
+    it("--offline never fetches; the uncached tool is skipped", async () => {
+      let calls = 0;
+      globalThis.fetch = (async () => {
+        calls++;
+        return new Response(JSON.stringify(textOnlyTool), { status: 200 });
+      }) as typeof fetch;
+
+      const wfPath = join(ctx.tmpDir, "offline.ga");
+      await writeFile(wfPath, JSON.stringify(fetchToolWorkflow()));
+      await runValidateWorkflow(wfPath, {
+        json: true,
+        offline: true,
+        cacheDir: join(ctx.tmpDir, "empty2"),
+      });
+
+      const report = parse();
+      expect(calls).toBe(0);
+      expect(report.results[0].status).toBe("skip_tool_not_found");
+    });
+
+    it("a fetch failure leaves the step skipped (graceful, not a crash)", async () => {
+      globalThis.fetch = (async () => new Response("not found", { status: 404 })) as typeof fetch;
+
+      const wfPath = join(ctx.tmpDir, "fetchfail.ga");
+      await writeFile(wfPath, JSON.stringify(fetchToolWorkflow()));
+      await runValidateWorkflow(wfPath, { json: true, cacheDir: join(ctx.tmpDir, "empty3") });
+
+      const report = parse();
+      expect(report.results[0].status).toBe("skip_tool_not_found");
     });
   });
 

--- a/packages/core/src/cache/tool-cache.ts
+++ b/packages/core/src/cache/tool-cache.ts
@@ -110,6 +110,24 @@ export class ToolCache {
   }
 
   /**
+   * Network-free lookup by tool id + version. Resolves coordinates, computes the
+   * cache key, and returns the cached tool alongside the key it lives under, or
+   * null on a miss (including an unpinned id that can't be keyed offline). The
+   * canonical "is this tool already cached?" read — callers must not re-derive
+   * the key themselves.
+   */
+  async loadByToolId(
+    toolId: string,
+    toolVersion?: string | null,
+  ): Promise<{ tool: ParsedTool; key: string } | null> {
+    const coords = this.resolveToolCoordinates(toolId, toolVersion);
+    if (coords.version === null) return null;
+    const key = await cacheKey(coords.toolshedUrl, coords.trsToolId, coords.version);
+    const tool = await this.loadCached(key);
+    return tool === null ? null : { tool, key };
+  }
+
+  /**
    * Load the raw cached payload without ParsedTool decoding.
    * Returns null only if the key is missing — surfaces stale or malformed entries
    * the inspector needs to render explicitly.

--- a/packages/core/src/tool-info.ts
+++ b/packages/core/src/tool-info.ts
@@ -55,6 +55,20 @@ export class ToolInfoService {
   }
 
   async getToolInfo(toolId: string, toolVersion?: string | null): Promise<ParsedTool | null> {
+    const resolved = await this.resolveTool(toolId, toolVersion);
+    return resolved === null ? null : resolved.tool;
+  }
+
+  /**
+   * Like {@link getToolInfo}, but also returns the cache key the tool lives under
+   * — the authoritative key this service caches with. Callers needing the key
+   * should use this rather than re-deriving it, so the subtle version-keying
+   * below stays owned in one place.
+   */
+  async resolveTool(
+    toolId: string,
+    toolVersion?: string | null,
+  ): Promise<{ tool: ParsedTool; key: string } | null> {
     const coords = this.cache.resolveToolCoordinates(toolId, toolVersion);
     // `keyVersion` keys the cache entry. The `_default_` sentinel is a stable handle
     // for an unversioned stock/built-in request and must survive as the key so the
@@ -74,7 +88,7 @@ export class ToolInfoService {
     // Check storage cache (ToolCache checks memory first internally). Done before any
     // `_default_` version discovery so cache hits stay network-free.
     const cached = await this.cache.loadCached(key);
-    if (cached !== null) return cached;
+    if (cached !== null) return { tool: cached, key };
 
     // Cache miss — pick the concrete version actually requested from the remote. For a
     // `_default_` request, resolve one now while keeping the key as `_default_`; fall back
@@ -120,7 +134,7 @@ export class ToolInfoService {
           sourceLabel,
           sourceUrl,
         );
-        return parsedTool;
+        return { tool: parsedTool, key };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.debug(
@@ -180,10 +194,12 @@ export class ToolInfoService {
     if (tool === null) {
       throw new Error(`Failed to fetch tool: ${toolId}`);
     }
-    // Mirror getToolInfo's keying: `_default_` and explicit pins key as-is
-    // (coords.version); an unpinned ToolShed tool (coords.version === null) keys by the
-    // resolved version. Must not key a stock tool by tool.version — its entry lives under
-    // the `_default_` key, not `~<version>`.
+    // Key derivation here is intentionally independent of getToolInfo's persistence
+    // (callers/tests treat getToolInfo as a mockable fetch seam that need not write
+    // the cache). Mirror its keying: `_default_` and explicit pins key as-is
+    // (coords.version); an unpinned ToolShed tool (coords.version === null) keys by
+    // the resolved version. Must not key a stock tool by tool.version — its entry
+    // lives under the `_default_` key, not `~<version>`.
     //
     // Known edge (tracked): a stock entry is keyed under `_default_` but its index/display
     // version is the concrete one (e.g. `1.1.1`). A caller that refetches by the *display*


### PR DESCRIPTION
## What

`gxwf validate` and `gxwf draft-validate --concrete` previously read only the local tool cache — any tool not already added via `galaxy-tool-cache add` was reported `skipped — not in cache`, so its `tool_state` went unchecked. They now **fetch missing tools on a cache miss**, cache them, and validate against the real tool. A fresh cache validates every step instead of silently skipping.

- `--offline` keeps the old behavior (read-only cache; uncached tools skipped).
- `--galaxy-url <url>` adds a Galaxy instance as a fallback source after the ToolShed.

The lower-level `validateNativeSteps` / `validateFormat2Steps` stay offline by default — fetching only happens when an explicit `ToolInfoService` is supplied — so callers passing only a cache are unaffected.

## Code-quality refactor

A thermo-nuclear review of the fetch wiring surfaced a real latent bug: the CLI re-derived the cache key after an online fetch (a copy of the service's fragile version-keying heuristic), so for unpinned tools it could return a `key` pointing at a **different** cache entry than the one actually written. Fixed by keeping key derivation in one place:

- **core** — `ToolInfoService.resolveTool(toolId, version)` returns `{ tool, key }` (the authoritative key it caches under); `getToolInfo` is now a thin `.tool` projection of it. `ToolCache.loadByToolId(toolId, version)` is the canonical network-free "is this cached?" read.
- **cli** — `resolveTool` (renamed from `loadCachedTool`, whose name no longer matched its fetch-and-cache behavior) is a slim online/offline dispatcher that consumes the service's key instead of re-deriving it. Online, it never touches the passed `cache` (the service's own cache is authoritative), so the two can't diverge. `describeResolveError()` de-dups the skip message shared by the native and format2 validators.

`ToolInfoService.refetch` intentionally still fetches via the mockable `getToolInfo` seam (its inspector contract derives the key independently of persistence), so it's unchanged.

## Tests

- New `packages/cli/test/resolve-tool.test.ts` — offline miss, fetch-on-miss + warm-cache reuse, fetch-failure reporting, and a round-trip assertion that the returned key is loadable from the cache (locks the bug fix).
- `validate-workflow.test.ts` gains coverage for default-online fetch, `--offline` opt-out, and graceful fetch-failure skips.
- Full `make check` + `make test` green (core, cli, gxwf-web, and all downstream packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)