### PR TITLE
fix(diagram): render step→step edges into labeled steps referenced by id

### DIFF
--- a/.changeset/mermaid-cytoscape-labeled-step-edges.md
+++ b/.changeset/mermaid-cytoscape-labeled-step-edges.md
@@ -1,0 +1,19 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+fix(diagram): render step→step edges into steps that carry an explicit label
+
+The mermaid and cytoscape builders key step nodes by render identity
+(`label || id`) but format2 `in:` sources address upstream steps by their dict
+`id` (e.g. `drhip.in.meme_files: meme/meme_output`). When a step had a distinct
+human `label:`, source resolution could not match the `id` reference, so every
+step→step edge into that step was silently dropped — `workflowToMermaid` left
+the downstream node orphaned and `cytoscapeElements` emitted a dangling edge to
+a non-existent node id. Input→step edges were unaffected (inputs are referenced
+by id and keyed by id), so diagrams looked deceptively sparse.
+
+Both builders now index steps by their dict `id` as well as their render
+identity and fold an `id`-form source reference back to that identity before
+node lookup, preserving the planned/concrete draft-overlay styling on the
+recovered edges.

--- a/packages/schema/src/workflow/cytoscape.ts
+++ b/packages/schema/src/workflow/cytoscape.ts
@@ -98,11 +98,23 @@ export function cytoscapeElements(
   const inputsOffset = wf.inputs.length;
   const knownLabels = new Set<string>();
   for (const inp of wf.inputs) knownLabels.add(inp.id);
-  for (const step of wf.steps) knownLabels.add(stepRenderIdentity(step));
+  // Maps a source-reference key (a step's dict `id` OR its render identity) to
+  // the render identity the node id is keyed by. `in:` sources address steps by
+  // `id` (e.g. `meme/out`) even when the step has a distinct `label:`.
+  const identityByKey = new Map<string, string>();
+  for (const step of wf.steps) {
+    const identity = stepRenderIdentity(step);
+    knownLabels.add(identity);
+    identityByKey.set(identity, identity);
+    if (step.id) {
+      knownLabels.add(step.id);
+      identityByKey.set(step.id, identity);
+    }
+  }
 
   wf.steps.forEach((step, i) => {
     nodes.push(_stepNode(step, i + inputsOffset, overlay));
-    edges.push(..._stepEdges(step, knownLabels, opts.edgeAnnotations, overlay));
+    edges.push(..._stepEdges(step, knownLabels, identityByKey, opts.edgeAnnotations, overlay));
   });
 
   const elements: CytoscapeElements = { nodes, edges };
@@ -237,6 +249,7 @@ function _stepNode(
 function _stepEdges(
   step: NormalizedFormat2Step,
   knownLabels: Set<string>,
+  identityByKey: Map<string, string>,
   edgeAnnotations: Map<string, EdgeAnnotation> | undefined,
   overlay: DraftOverlay | undefined,
 ): CytoscapeEdge[] {
@@ -247,7 +260,10 @@ function _stepEdges(
     const inputId = stepInput.id || "unknown";
     const sources = Array.isArray(stepInput.source) ? stepInput.source : [stepInput.source];
     for (const source of sources) {
-      const [sourceLabel, outputName] = resolveSourceReference(source, knownLabels);
+      const [sourceRef, outputName] = resolveSourceReference(source, knownLabels);
+      // Fold a step `id` reference back to the render identity the node id is
+      // keyed by; input refs (not in the map) pass through unchanged.
+      const sourceLabel = identityByKey.get(sourceRef) ?? sourceRef;
       const output = outputName === "output" ? null : outputName;
       const edgeId = `${stepId}__${inputId}__from__${sourceLabel}`;
       const edge: CytoscapeEdge = {

--- a/packages/schema/src/workflow/mermaid.ts
+++ b/packages/schema/src/workflow/mermaid.ts
@@ -144,11 +144,18 @@ export function workflowToMermaid(
 
   const stepIds = new Map<string, string>();
   const stepLines = new Map<string, string>();
+  // Maps a source-reference key (a step's dict `id` OR its render identity) to
+  // the render identity the node is keyed by. `in:` sources address steps by
+  // `id` (e.g. `meme/out`) even when the step carries a distinct `label:`, so
+  // resolution must fold the `id` back to the render identity.
+  const identityByKey = new Map<string, string>();
   const plannedNodeIds: string[] = [];
   wf.steps.forEach((step, i) => {
     const nodeId = `step_${i}`;
     const stepLabel = stepRenderIdentity(step);
     stepIds.set(stepLabel, nodeId);
+    identityByKey.set(stepLabel, stepLabel);
+    if (step.id) identityByKey.set(step.id, stepLabel);
     if (overlay?.plannedSteps.has(stepLabel)) plannedNodeIds.push(nodeId);
 
     let toolId = step.tool_id ?? null;
@@ -193,8 +200,13 @@ export function workflowToMermaid(
     lines.push("    end");
   });
 
-  // Build the set of known labels for source resolution: input ids + step labels/ids.
-  const knownLabels = new Set<string>([...inputIds.keys(), ...stepIds.keys()]);
+  // Build the set of known labels for source resolution: input ids + step
+  // render identities + step dict ids (so `id/out`-form sources split right).
+  const knownLabels = new Set<string>([
+    ...inputIds.keys(),
+    ...stepIds.keys(),
+    ...identityByKey.keys(),
+  ]);
 
   const seenEdges = new Set<string>();
   const linkStyles: string[] = [];
@@ -207,7 +219,10 @@ export function workflowToMermaid(
       const inputId = stepInput.id || "";
       const sources = Array.isArray(stepInput.source) ? stepInput.source : [stepInput.source];
       for (const source of sources) {
-        const [sourceLabel, outputName] = resolveSourceReference(source, knownLabels);
+        const [sourceRef, outputName] = resolveSourceReference(source, knownLabels);
+        // Fold a step `id` reference back to the render identity the node and
+        // overlay are keyed by; input refs (not in the map) pass through.
+        const sourceLabel = identityByKey.get(sourceRef) ?? sourceRef;
         const sourceId = inputIds.get(sourceLabel) ?? stepIds.get(sourceLabel);
         if (!sourceId) continue;
         const edgeKey = `${sourceId}->${nodeId}`;

--- a/packages/schema/test/diagram-unlabeled-fallback.test.ts
+++ b/packages/schema/test/diagram-unlabeled-fallback.test.ts
@@ -56,3 +56,52 @@ describe("diagram unlabeled-step fallback", () => {
     expect(toolNode!.data.label).toBe("tool:devteam/cat1/cat1/1.0.0");
   });
 });
+
+// A format2 step references an upstream step by its dict `id` (`upstream/out`)
+// even when that upstream carries a distinct human `label:`. The builders key
+// nodes by render identity (`label || id`), so source resolution must fold the
+// `id` reference back to that identity — otherwise the step→step edge is
+// silently dropped and the downstream node renders orphaned.
+const FORMAT2_LABELED_REF = {
+  class: "GalaxyWorkflow",
+  inputs: { in_file: { type: "data" } },
+  outputs: {},
+  steps: {
+    upstream: {
+      label: "Upstream Tool With Label",
+      tool_id: "toolshed.g2.bx.psu.edu/repos/iuc/up/up/1.0",
+      tool_version: "1.0",
+      in: { input: "in_file" },
+      out: [{ id: "out" }],
+    },
+    downstream: {
+      label: "Downstream Tool With Label",
+      tool_id: "toolshed.g2.bx.psu.edu/repos/iuc/down/down/1.0",
+      tool_version: "1.0",
+      in: { data: "upstream/out" },
+      out: [{ id: "result" }],
+    },
+  },
+};
+
+describe("diagram source resolution by step id", () => {
+  it("mermaid: edge to a labeled step referenced by its dict id is rendered", () => {
+    const diagram = workflowToMermaid(FORMAT2_LABELED_REF);
+    // upstream → downstream is step_0 → step_1 (inputs are not steps here).
+    expect(diagram).toContain("step_0 --> step_1");
+  });
+
+  it("cytoscape: edge to a labeled step referenced by its dict id targets real nodes", () => {
+    const els = cytoscapeElements(FORMAT2_LABELED_REF);
+    const nodeIds = new Set(els.nodes.map((n) => n.data.id));
+    const edge = els.edges.find(
+      (e) => e.data.target === "Downstream Tool With Label" && e.data.input === "data",
+    );
+    expect(edge).toBeDefined();
+    // Source resolves to the upstream node's render identity, not the raw `id`.
+    expect(edge!.data.source).toBe("Upstream Tool With Label");
+    // No dangling endpoints — both ends are real nodes.
+    expect(nodeIds.has(edge!.data.source)).toBe(true);
+    expect(nodeIds.has(edge!.data.target as string)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes a bug where the Mermaid and Cytoscape workflow diagram builders silently dropped (or dangled) `step→step` edges whose source addresses an upstream step by its dict **`id`** when that step carries a distinct **`label:`**.

Both builders key step nodes by render identity (`label || id`), but format2 `in:` sources address upstream steps by their dict `id` (e.g. `in: { data: meme/meme_output }`). When a step had a distinct human `label:`, source resolution couldn't match the `id` reference, so:

- `workflowToMermaid` dropped the `step→step` edge, leaving the downstream node **orphaned**;
- `cytoscapeElements` emitted a **dangling edge** to a non-existent node id.

Input→step edges were unaffected (inputs are referenced by id and keyed by id), so diagrams just looked deceptively sparse rather than erroring.

## Fix

Both builders now index steps by their dict `id` **as well as** their render identity, and fold an `id`-form source reference back to that identity before node lookup. Draft-overlay (planned/concrete) styling is preserved on the recovered edges. The common case (`label == id`) is unchanged — the fold is the identity function there.

## Tests

Added `diagram source resolution by step id` cases (mermaid + cytoscape) covering a format2 step referenced by its dict id while carrying a distinct label. Full schema suite green (4969 pass), `make check` clean.

## Notes

- Verified there's **zero regression risk for native workflows**: across all 90 IWC native `.ga` workflows, the `id`-ref-to-distinct-label case never arises (native→format2 keeps reference-head == render-identity).
- The Python reference impl (`gxformat2`) has the **same defect** — reproduced and filed upstream as [galaxyproject/gxformat2#228](https://github.com/galaxyproject/gxformat2/issues/228). This PR makes the TS builders lenient enough to render the edge regardless, which is the right call for a visualization helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
