### PR TITLE
fix(validate): fail hallucinated stock-tool version pins (#139)

### DIFF
--- a/.changeset/concrete-stock-version-mismatch.md
+++ b/.changeset/concrete-stock-version-mismatch.md
@@ -1,0 +1,12 @@
+---
+"@galaxy-tool-util/cli": patch
+---
+
+fix(validate): fail a hallucinated stock-tool version pin instead of skipping it.
+When tool-state validation resolves a built-in/stock step (bare id — `Cut1`,
+`Show beginning1`, `__APPLY_RULES__`) and the pinned version misses but the shed
+resolves the tool at a different concrete version, the pin is now reported as a
+`fail` (`stock_version_mismatch`) rather than a silent `skip_tool_not_found`.
+Closes the `gxwf draft-validate --concrete` loophole where a guessed stock
+version validated green (#139). The offline / no-service path is unchanged: a
+tool that can't be resolved at all still skips.

--- a/packages/cli/src/commands/resolve-tool.ts
+++ b/packages/cli/src/commands/resolve-tool.ts
@@ -1,4 +1,10 @@
-import { type ToolCache, type ToolInfoService, cacheKey } from "@galaxy-tool-util/core";
+import {
+  type ToolCache,
+  type ToolInfoService,
+  cacheKey,
+  normalizeShortTrsToolId,
+  parseToolshedToolId,
+} from "@galaxy-tool-util/core";
 import { makeNodeToolCache, makeNodeToolInfoService } from "@galaxy-tool-util/core/node";
 import type { ParsedTool } from "@galaxy-tool-util/schema";
 
@@ -9,18 +15,64 @@ export interface ResolvedTool {
 
 export type ResolveError =
   | { kind: "no_version"; toolId: string }
-  | { kind: "not_cached"; toolId: string; key: string; fetchAttempted?: boolean };
+  | { kind: "not_cached"; toolId: string; key: string; fetchAttempted?: boolean }
+  | {
+      kind: "stock_version_mismatch";
+      toolId: string;
+      pinnedVersion: string;
+      resolvedVersion: string;
+    };
 
 export function isResolveError(r: ResolvedTool | ResolveError): r is ResolveError {
   return "kind" in r;
 }
 
-/** Human-readable reason a tool failed to resolve, for skip messages. */
+/**
+ * Whether a resolve error should fail validation rather than skip it. A
+ * hallucinated stock-tool pin (`stock_version_mismatch`) is a hard error — the
+ * tool exists but not at the pinned version; every other miss is a skip.
+ */
+export function resolveErrorIsFailure(err: ResolveError): boolean {
+  return err.kind === "stock_version_mismatch";
+}
+
+/** Human-readable reason a tool failed to resolve, for skip/fail messages. */
 export function describeResolveError(err: ResolveError): string {
   if (err.kind === "no_version") return `no version for ${err.toolId}`;
+  if (err.kind === "stock_version_mismatch") {
+    return `${err.toolId} pinned version ${err.pinnedVersion} does not exist (resolves to ${err.resolvedVersion})`;
+  }
   return err.fetchAttempted
     ? `${err.toolId} not in cache (fetch failed)`
     : `${err.toolId} not in cache`;
+}
+
+/**
+ * A stock/built-in Galaxy tool id: a bare id carrying no owner/repo — `Cut1`,
+ * `Show beginning1`, collection ops, `__APPLY_RULES__`. Neither a full ToolShed
+ * id nor the `owner/repo/tool` short form. The ToolShed can still resolve these
+ * by bare id even though it doesn't host them as repos.
+ */
+function isStockToolId(toolId: string): boolean {
+  return parseToolshedToolId(toolId) === null && normalizeShortTrsToolId(toolId) === null;
+}
+
+/**
+ * A pinned stock version missed. Ask the shed for the tool version-agnostically:
+ * if it resolves to a *different* concrete version, the pin is a hallucination —
+ * flag it as a hard error. If the tool can't be resolved at all (offline, unknown
+ * to the shed) we can't prove the pin wrong, so return null and let it skip.
+ */
+async function detectStockVersionMismatch(
+  service: ToolInfoService,
+  toolId: string,
+  pinnedVersion: string,
+): Promise<ResolveError | null> {
+  const anyVersion = await service.resolveTool(toolId, null);
+  if (anyVersion === null) return null;
+  const resolvedVersion = anyVersion.tool.version;
+  if (resolvedVersion == null || resolvedVersion === pinnedVersion) return null;
+  return { kind: "stock_version_mismatch", toolId, pinnedVersion, resolvedVersion };
 }
 
 /**
@@ -39,6 +91,13 @@ export async function resolveTool(
   if (service) {
     const resolved = await service.resolveTool(toolId, version ?? null);
     if (resolved !== null) return resolved;
+    // A pinned stock version that missed may be a hallucinated guess. If the shed
+    // resolves the tool at a different version, treat the pin as a hard error
+    // rather than a silent skip (closes the #139 draft-validate loophole).
+    if (version != null && isStockToolId(toolId)) {
+      const mismatch = await detectStockVersionMismatch(service, toolId, version);
+      if (mismatch !== null) return mismatch;
+    }
     return notCached(cache, toolId, version, true);
   }
   const hit = await cache.loadByToolId(toolId, version ?? null);

--- a/packages/cli/src/commands/validate-workflow.ts
+++ b/packages/cli/src/commands/validate-workflow.ts
@@ -29,6 +29,7 @@ import {
   isResolveError,
   resolveTool,
   describeResolveError,
+  resolveErrorIsFailure,
   makeValidationResolver,
 } from "./resolve-tool.js";
 import { createDefaultResolver } from "./url-resolver.js";
@@ -324,7 +325,7 @@ async function _validateNativeStep(
       step: stepLabel,
       tool_id: toolId,
       version: toolVersion,
-      status: "skip_tool_not_found",
+      status: resolveErrorIsFailure(resolved) ? "fail" : "skip_tool_not_found",
       errors: [reason],
     };
   }
@@ -470,7 +471,7 @@ async function _validateFormat2Step(
       step: stepLabel,
       tool_id: toolId,
       version: toolVersion,
-      status: "skip_tool_not_found",
+      status: resolveErrorIsFailure(resolved) ? "fail" : "skip_tool_not_found",
       errors: [reason],
     };
   }

--- a/packages/cli/test/resolve-tool.test.ts
+++ b/packages/cli/test/resolve-tool.test.ts
@@ -77,4 +77,70 @@ describe("resolveTool", () => {
       expect(result.fetchAttempted).toBe(true);
     }
   });
+
+  describe("stock/built-in tools", () => {
+    const STOCK_ID = "Show beginning1";
+
+    function jsonResponse(body: unknown): Response {
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    /** Shed that only knows `Show beginning1` at version 1.0.2. */
+    function stockShedFetcher(): typeof fetch {
+      return (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        // TRS versions listing → newest last.
+        if (url.includes("/api/ga4gh/trs/v2/tools/") && url.endsWith("/versions")) {
+          return jsonResponse([
+            { id: "1.0.2", name: null, url: "", descriptor_type: ["GALAXY"], author: [] },
+          ]);
+        }
+        // Concrete-version fetch — only 1.0.2 exists.
+        if (url.includes("/versions/1.0.2")) {
+          return jsonResponse({ ...textOnlyTool, id: STOCK_ID, version: "1.0.2" });
+        }
+        return new Response("nope", { status: 404 });
+      }) as typeof fetch;
+    }
+
+    it("flags a hallucinated stock pin as stock_version_mismatch", async () => {
+      const service = makeNodeToolInfoService({ cacheDir: tmpDir, fetcher: stockShedFetcher() });
+      const result = await resolveTool(service.cache, STOCK_ID, "1.0.0", service);
+      expect(isResolveError(result)).toBe(true);
+      if (isResolveError(result)) {
+        expect(result.kind).toBe("stock_version_mismatch");
+        if (result.kind === "stock_version_mismatch") {
+          expect(result.pinnedVersion).toBe("1.0.0");
+          expect(result.resolvedVersion).toBe("1.0.2");
+        }
+      }
+    });
+
+    it("resolves a correctly pinned stock version", async () => {
+      const service = makeNodeToolInfoService({ cacheDir: tmpDir, fetcher: stockShedFetcher() });
+      const result = await resolveTool(service.cache, STOCK_ID, "1.0.2", service);
+      expect(isResolveError(result)).toBe(false);
+      if (!isResolveError(result)) expect(result.tool.version).toBe("1.0.2");
+    });
+
+    it("skips (not_cached) a stock tool the shed can't resolve at all", async () => {
+      const service = makeNodeToolInfoService({
+        cacheDir: tmpDir,
+        fetcher: (async () => new Response("nope", { status: 404 })) as typeof fetch,
+      });
+      const result = await resolveTool(service.cache, STOCK_ID, "1.0.0", service);
+      expect(isResolveError(result)).toBe(true);
+      if (isResolveError(result)) expect(result.kind).toBe("not_cached");
+    });
+
+    it("does not flag a shed (owner/repo) tool with a bad version as a stock mismatch", async () => {
+      const service = makeNodeToolInfoService({ cacheDir: tmpDir, fetcher: stockShedFetcher() });
+      const result = await resolveTool(service.cache, TOOL_ID, "9.9.9", service);
+      expect(isResolveError(result)).toBe(true);
+      if (isResolveError(result)) expect(result.kind).toBe("not_cached");
+    });
+  });
 });


### PR DESCRIPTION
Closes #139.

## Problem

`gxwf draft-validate --concrete` (and `gxwf validate`) validated a **hallucinated built-in/stock version pin green**. A stock step like `Show beginning1` pinned to `1.0.0` when the real version is `1.0.2` resolved to `skip_tool_not_found` — a *skip*, which doesn't fail validation — so the bad guess only surfaced much later at terminal validate as a confusing "not in cache". This is the back half of galaxyproject/foundry#323.

## Fix

The discriminator: for a **bare stock id** (no `owner/repo` — `Cut1`, `Show beginning1`, collection ops, `__APPLY_RULES__`), when the pinned version misses but a fetch service is present, `resolveTool` re-resolves the tool **version-agnostically** against the shed. If the shed resolves it at a *different* concrete version, the pin is a hallucination → new `stock_version_mismatch` resolve error → `validate-workflow` maps it to a **`fail`** (exit 1 / concrete `FAIL`) instead of a skip.

- Reuses the existing `ToolInfoService.resolveTool` and the shed's ability to resolve stock tools by bare id — no `--galaxy-url` or pre-populated built-in cache needed.
- **Structure-only / offline path unchanged:** no service (or a tool the shed can't resolve at all) still skips, so `--no-cache-dir` and `--offline` keep working.
- **Shed (`owner/repo`) tools unaffected:** the check is gated to stock ids only.

## Tests

New `resolve-tool.test.ts` cases:
- hallucinated stock pin → `stock_version_mismatch` (pinned `1.0.0`, resolves `1.0.2`)
- correctly pinned stock version → resolves
- stock tool the shed can't resolve at all → `not_cached` (skip)
- shed `owner/repo` tool with a bad version → `not_cached`, *not* a stock mismatch

Full CLI suite green (354 passed / 14 skipped); `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)