### PR TITLE
fix(draft): resolve bare-step outputSource shorthand across draft toolchain

### DIFF
--- a/.changeset/draft-bare-step-outputsource.md
+++ b/.changeset/draft-bare-step-outputsource.md
@@ -1,0 +1,12 @@
+---
+"@galaxy-tool-util/schema": patch
+---
+
+Fix draft-workflow tooling rejecting/mishandling the gxformat2 bare-step
+`outputSource`/`source` shorthand (`<step>`, resolving to `<step>/output`) that
+`validate` and Galaxy accept. `draft-validate` now parses source refs through
+the shared `resolveSourceReference` used by the concrete conversion path, and
+`draft-next-step` / `draft-extract` resolve bare-step refs consistently — so
+topological ordering, cascade-dropping, and output trimming all treat a bare
+`<step>` as a step edge instead of a workflow input. The "unmatched" validation
+error also no longer misreports a step reference as a workflow input.

--- a/packages/schema/src/workflow/draft-checks.ts
+++ b/packages/schema/src/workflow/draft-checks.ts
@@ -12,7 +12,7 @@
 import { Either, ParseResult, Schema } from "effect";
 
 import { GalaxyWorkflowDraftSchema } from "./raw/gxformat2-draft.effect.js";
-import { rawStepRenderIdentity } from "./normalized/labels.js";
+import { rawStepRenderIdentity, resolveSourceReference } from "./normalized/labels.js";
 
 export const TODO_SENTINEL_PATTERN = /^TODO(_[a-zA-Z0-9_]+)?$/;
 // Heuristic for TODO-shaped strings — flags malformed sentinels (TODO-foo,
@@ -203,10 +203,11 @@ function walkDraftSteps(
   // reach this workflow (i.e. the outer step's path); inner outputs collect
   // at that prefix. For the outermost call `prefix` is [], so outer outputs
   // collect at path [].
+  const stepLabels = collectStepLabels(workflow.steps);
   for (const [label, output] of iterateOutputs(workflow.outputs)) {
     const ref = readOutputSource(output);
     if (ref == null) continue;
-    const [, port] = splitSourceRef(ref);
+    const [, port] = splitSourceRef(ref, stepLabels);
     if (port != null && isTodoSentinel(port)) {
       todos.push({
         path: prefix,
@@ -293,10 +294,29 @@ function readOutputSource(output: unknown): string | null {
   return typeof src === "string" ? src : null;
 }
 
-function splitSourceRef(ref: string): [string, string | null] {
+/**
+ * Anything answering membership for a step label — a `Set` of labels or the
+ * `livePorts`/`stepIndex` maps keyed by label both qualify.
+ */
+type StepLabelSet = { has(label: string): boolean };
+
+function collectStepLabels(steps: unknown): Set<string> {
+  const labels = new Set<string>();
+  for (const [label] of iterateSteps(steps)) labels.add(label);
+  return labels;
+}
+
+/**
+ * Parse a source ref into `[label, port]`. A slash-less ref that names a step
+ * is gxformat2 shorthand for `<step>/output` (matching `resolveSourceReference`
+ * on the concrete path and `checkEdgeRef`); anything else is a workflow-input
+ * ref, reported port-less (`null`) so callers can treat it as a non-step edge.
+ */
+function splitSourceRef(ref: string, stepLabels: StepLabelSet): [string, string | null] {
   const slash = ref.indexOf("/");
-  if (slash < 0) return [ref, null];
-  return [ref.slice(0, slash), ref.slice(slash + 1)];
+  if (slash >= 0) return [ref.slice(0, slash), ref.slice(slash + 1)];
+  if (stepLabels.has(ref)) return [ref, "output"];
+  return [ref, null];
 }
 
 function* iterateStepOutIds(out: unknown): Iterable<string> {
@@ -452,6 +472,9 @@ function walkDraftValidation(
 
   // Workflow outputs: labels must be concrete; outputSource resolves.
   const stepIndex = buildStepIndex(workflow.steps);
+  // The label universe every edge ref resolves against — built once per level
+  // and shared by the output and step-input edge checks below.
+  const knownLabels = new Set<string>([...inputLabels, ...stepIndex.keys()]);
   for (const [label, output] of iterateMapOrArrayLabeled(workflow.outputs)) {
     if (isTodoSentinel(label)) {
       topologyErrors.push({
@@ -469,6 +492,7 @@ function walkDraftValidation(
         `workflow output "${label}"`,
         stepIndex,
         inputLabels,
+        knownLabels,
         topologyErrors,
         semanticErrors,
       );
@@ -525,6 +549,7 @@ function walkDraftValidation(
           `step input "${inKey}"`,
           stepIndex,
           inputLabels,
+          knownLabels,
           topologyErrors,
           semanticErrors,
         );
@@ -604,36 +629,39 @@ function checkEdgeRef(
   context: string,
   stepIndex: Map<string, StepIndexEntry>,
   inputLabels: Set<string>,
+  knownLabels: Set<string>,
   topologyErrors: DraftValidationDiagnostic[],
   semanticErrors: DraftValidationDiagnostic[],
 ): void {
   checkTodoLike(ref, path, `${context} source "${ref}"`, semanticErrors);
-  const slash = ref.indexOf("/");
-  if (slash < 0) {
-    if (!inputLabels.has(ref)) {
+  // Parse via the shared resolver so draft-validate agrees with the concrete
+  // conversion path on what a source string means. A bare ref that names a
+  // step is gxformat2 shorthand for `<step>/output`; the resolver returns
+  // `[step, "output"]`, and matching known labels longest-first also handles
+  // labels that contain a slash.
+  const [label, port] = resolveSourceReference(ref, knownLabels);
+  // Consult steps before inputs so a label shared by both resolves the same way
+  // the concrete conversion path does: `_registerLabels` registers inputs first
+  // then steps into one map, so a step overwrites a colliding input and wins.
+  const entry = stepIndex.get(label);
+  if (entry != null) {
+    if (!entry.outPorts.has(port)) {
       topologyErrors.push({
         path,
-        message: `${context} source "${ref}" does not match any declared workflow input`,
+        message: `${context} source "${ref}" references unknown port "${port}" on step "${label}"`,
       });
     }
     return;
   }
-  const stepLabel = ref.slice(0, slash);
-  const port = ref.slice(slash + 1);
-  const entry = stepIndex.get(stepLabel);
-  if (entry == null) {
-    topologyErrors.push({
-      path,
-      message: `${context} source "${ref}" references unknown step "${stepLabel}"`,
-    });
+  if (inputLabels.has(label)) {
     return;
   }
-  if (!entry.outPorts.has(port)) {
-    topologyErrors.push({
-      path,
-      message: `${context} source "${ref}" references unknown port "${port}" on step "${stepLabel}"`,
-    });
-  }
+  // An explicit `<step>/<port>` ref names a step; a bare ref could have meant
+  // either an input or a step — keep each message accurate to the input.
+  const message = ref.includes("/")
+    ? `${context} source "${ref}" references unknown step "${label}"`
+    : `${context} source "${ref}" does not match any declared workflow input or step`;
+  topologyErrors.push({ path, message });
 }
 
 function* iterateStepInputEntries(input: unknown): Iterable<[string, unknown]> {
@@ -709,7 +737,7 @@ export function nextDraftStep(workflow: unknown): NextStepResult {
 
 function nextDraftStepIn(workflow: Record<string, unknown>, prefix: StepPath): NextStepResult {
   const ordered = topoOrderedSteps(workflow.steps);
-  const outputRefs = collectOutputRefs(workflow.outputs);
+  const outputRefs = collectOutputRefs(workflow.outputs, collectStepLabels(workflow.steps));
 
   for (const [label, step] of ordered) {
     if (!isRecord(step)) continue;
@@ -759,9 +787,8 @@ function topoOrderedSteps(steps: unknown): Array<[string, unknown]> {
     const seen = new Set<string>();
     for (const [, inValue] of iterateStepInputEntries(step.in)) {
       for (const ref of extractSourceRefs(inValue)) {
-        const slash = ref.indexOf("/");
-        if (slash < 0) continue;
-        const depLabel = ref.slice(0, slash);
+        const [depLabel, port] = splitSourceRef(ref, stepLabels);
+        if (port == null) continue; // workflow-input ref — not a step edge
         if (depLabel !== label && stepLabels.has(depLabel)) {
           seen.add(depLabel);
         }
@@ -805,12 +832,12 @@ interface OutputRefIndex {
   byStepPort: Map<string, Map<string, Set<string>>>;
 }
 
-function collectOutputRefs(outputs: unknown): OutputRefIndex {
+function collectOutputRefs(outputs: unknown, stepLabels: StepLabelSet): OutputRefIndex {
   const byStepPort = new Map<string, Map<string, Set<string>>>();
   for (const [label, output] of iterateOutputs(outputs)) {
     const ref = readOutputSource(output);
     if (ref == null) continue;
-    const [stepLabel, port] = splitSourceRef(ref);
+    const [stepLabel, port] = splitSourceRef(ref, stepLabels);
     if (port == null) continue;
     let perPort = byStepPort.get(stepLabel);
     if (perPort == null) {
@@ -1174,7 +1201,7 @@ function checkStepCascade(
     let anyAlive = false;
     const localDeps: Array<[string, StepPath]> = [];
     for (const ref of refs) {
-      const [refStep, refPort] = splitSourceRef(ref);
+      const [refStep, refPort] = splitSourceRef(ref, stepLabels);
       if (refPort == null) {
         // Workflow input ref — always alive (workflow inputs are preserved verbatim).
         anyAlive = true;
@@ -1298,7 +1325,9 @@ function refIsDead(
   drops: Map<string, InternalDroppedStep>,
   livePorts: Map<string, Set<string>>,
 ): boolean {
-  const [refStep, refPort] = splitSourceRef(ref);
+  // livePorts is keyed by every step label at this level (dropped steps get an
+  // empty set), so it doubles as the step-label universe for splitSourceRef.
+  const [refStep, refPort] = splitSourceRef(ref, livePorts);
   if (refPort == null) return false;
   if (drops.has(refStep)) return true;
   const ports = livePorts.get(refStep);
@@ -1520,7 +1549,7 @@ function trimOutputsContainer(
     const ref = readOutputSource(value);
     if (ref == null) return true;
     if (!refIsDead(ref, drops, livePorts)) return true;
-    const [refStep] = splitSourceRef(ref);
+    const [refStep] = splitSourceRef(ref, livePorts);
     const drop = drops.get(refStep);
     const reason: DropReason =
       drop != null

--- a/packages/schema/test/draft-checks.test.ts
+++ b/packages/schema/test/draft-checks.test.ts
@@ -245,6 +245,70 @@ describe("validateDraft", () => {
     );
   });
 
+  it("accepts a bare step ref as `<step>/output` shorthand (matches validate/gxformat2)", () => {
+    const r = validateDraft({
+      class: DRAFT_CLASS,
+      inputs: { in1: { type: "data" } },
+      outputs: { out1: { outputSource: "step1" } },
+      steps: {
+        step1: {
+          tool_id: "cat1",
+          tool_version: "1.0.0",
+          in: { input1: "in1" },
+          out: [{ id: "output" }],
+        },
+        step2: {
+          tool_id: "cat1",
+          tool_version: "1.0.0",
+          in: { input1: "step1" },
+          out: [{ id: "output" }],
+        },
+      },
+    });
+    expect(r.topologyErrors).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+
+  it("errors on a bare ref matching neither an input nor a step", () => {
+    const r = validateDraft({
+      class: DRAFT_CLASS,
+      inputs: { in1: { type: "data" } },
+      outputs: { out1: { outputSource: "nope" } },
+      steps: {
+        step1: {
+          tool_id: "cat1",
+          tool_version: "1.0.0",
+          in: { input1: "in1" },
+          out: [{ id: "output" }],
+        },
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.topologyErrors.map((e) => e.message)).toContain(
+      `workflow output "out1" source "nope" does not match any declared workflow input or step`,
+    );
+  });
+
+  it("errors on a bare step ref whose step has no `output` port", () => {
+    const r = validateDraft({
+      class: DRAFT_CLASS,
+      inputs: { in1: { type: "data" } },
+      outputs: { out1: { outputSource: "step1" } },
+      steps: {
+        step1: {
+          tool_id: "cat1",
+          tool_version: "1.0.0",
+          in: { input1: "in1" },
+          out: [{ id: "renamed" }],
+        },
+      },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.topologyErrors.map((e) => e.message)).toContain(
+      `workflow output "out1" source "step1" references unknown port "output" on step "step1"`,
+    );
+  });
+
   it("allows TODO_<hint> ports as edge sources (drafts may reference unresolved ports)", () => {
     const r = validateDraft({
       class: DRAFT_CLASS,
@@ -620,6 +684,34 @@ describe("nextDraftStep", () => {
       "TODO[out.TODO]: assign the real wrapper output port name",
     ]);
   });
+
+  it("orders a bare-step dependency before its dependent (topological, not just alphabetical)", () => {
+    // `alpha` depends on `zebra` via the bare-step shorthand `zebra` (= zebra/output).
+    // Both need work; zebra must be surfaced first topologically even though alpha
+    // sorts earlier alphabetically. Pre-fix the bare dep wasn't recorded as an edge,
+    // so both landed at level 0 and alphabetical tie-break wrongly picked alpha.
+    const wf = {
+      class: DRAFT_CLASS,
+      inputs: { reads: { type: "data" } },
+      outputs: {},
+      steps: {
+        alpha: {
+          tool_id: "TODO",
+          tool_version: "TODO",
+          in: { x: "zebra" },
+          out: [{ id: "output" }],
+        },
+        zebra: {
+          tool_id: "TODO",
+          tool_version: "TODO",
+          in: { x: "reads" },
+          out: [{ id: "output" }],
+        },
+      },
+    };
+    const result = nextDraftStep(wf);
+    expect(result).toMatchObject({ draft: true, step: ["zebra"] });
+  });
 });
 
 describe("fix-ups (review feedback)", () => {
@@ -877,6 +969,38 @@ describe("extractConcreteSubset", () => {
     ).c?.in as Record<string, unknown>;
     // 1 surviving ref collapses to string form on the source field.
     expect(cIn.joined).toEqual({ source: "b/out1" });
+  });
+
+  it("cascade-drops a step (and its output) sourced from a dropped step via a bare-step ref", () => {
+    // `keep`'s only source is the bare-step shorthand `bad` (= bad/output), and
+    // the workflow output is `outputSource: keep`. When the TODO step `bad` is
+    // dropped, `keep` must cascade-drop and the output must drop with it. Pre-fix
+    // the bare refs read as workflow-input refs (always alive), leaving `keep`
+    // and the output dangling on a removed step in the "concrete" subset.
+    const wf = {
+      class: DRAFT_CLASS,
+      inputs: { reads: { type: "data" } },
+      outputs: { out1: { outputSource: "keep" } },
+      steps: {
+        bad: {
+          tool_id: "TODO",
+          tool_version: "TODO",
+          in: { input1: "reads" },
+          out: [{ id: "output" }],
+        },
+        keep: {
+          tool_id: "cat1",
+          tool_version: "1.0.0",
+          in: { input1: "bad" },
+          out: [{ id: "output" }],
+        },
+      },
+    };
+    const r = extractConcreteSubset(wf);
+    expect(r.dropped_steps.map((d) => d.path)).toEqual([["bad"], ["keep"]]);
+    expect(r.dropped_outputs.map((o) => o.label)).toEqual(["out1"]);
+    const steps = (r.workflow as Record<string, unknown>).steps as Record<string, unknown>;
+    expect(Object.keys(steps)).toEqual([]);
   });
 
   it("rewrites multi-source inputs to the surviving ref subset (list carrier with 2 left)", () => {


### PR DESCRIPTION
Closes #155.

## Problem

gxformat2 treats `outputSource: <step>` (and step `in.source: <step>`) as shorthand for `<step>/output` — `gxwf validate` and Galaxy accept it, and IWC workflows ship it. But `gxwf draft-validate` rejected it, and the error misreported the step reference as an unmatched workflow **input**:

```
workflow output "out1" source "step1" does not match any declared workflow input
```

The concrete path resolves bare refs via `resolveSourceReference`; the draft checker reimplemented resolution with a naive `indexOf("/")` and only matched bare refs against workflow inputs.

## Fix — converge on the shared resolver

- **`checkEdgeRef`** now parses through `resolveSourceReference` (the same resolver `toNative`/`mermaid`/`cytoscape` use), consulting steps before inputs to match `_registerLabels` step-wins precedence. Corrects the misleading message and, for free, fixes a latent mis-parse of labels containing a slash.
- **`splitSourceRef`** is now step-label-aware. This matters beyond `validate`: `draft-next-step` (`topoOrderedSteps`) and `draft-extract` (`checkStepCascade`/`refIsDead`/`trimOutputsContainer`) previously read any slash-less ref as a workflow-input ref. Making bare-step refs *valid* would have exposed those as real bugs — mis-ordered next-steps and dangling refs to dropped steps in the extracted subset. Now the whole toolchain agrees a bare `<step>` is a step edge (`<step>/output`).
- Hoisted the per-edge label set to once per validation level.

## Tests

- `draft-validate`: bare-step ref valid; unknown bare ref errors with corrected `input or step` message; bare ref to a step lacking an `output` port still errors (draft stays at least as strict as the fully-qualified form).
- `draft-next-step`: a bare-step dependency now orders topologically ahead of its dependent, not just alphabetically.
- `draft-extract`: a step (and its output) sourced from a dropped step via a bare-step ref cascade-drops instead of surviving dangling.

All new consumer tests verified red→green. Full `make test` + `make check` green.

---
> Investigated, implemented, and PR-authored by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)