### PR TITLE
feat(cli): galaxy-tool-cache add-local — cache a local tool file (XML/YAML)

### DIFF
--- a/.changeset/cli-add-local.md
+++ b/.changeset/cli-add-local.md
@@ -1,0 +1,8 @@
+---
+"@galaxy-tool-util/cli": minor
+"@galaxy-tool-util/tool-xml": minor
+---
+
+Add `galaxy-tool-cache add-local <tool_path>` — parse a local tool file into a `ParsedTool` and cache it with `source: local`, the local-ingest counterpart to `add` (which fetches from the ToolShed). Dispatches on extension like Galaxy's `get_tool_source`: `.yml` → YAML tool, everything else → XML (CWL is not supported). Mirrors Galaxy's `galaxy-tool-cache add-local`: `--tool-id` (the full toolshed tool_id) is required for cache keying even when the file carries a bare id, which is surfaced only as a hint; `--tool-version` overrides the parsed version.
+
+`@galaxy-tool-util/tool-xml` now exports `loadToolFile(path)` (extension-dispatching XML/YAML loader → `ParsedTool`) and `loadYamlTool(path)`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "@galaxy-tool-util/core": "workspace:*",
     "@galaxy-tool-util/schema": "workspace:*",
     "@galaxy-tool-util/search": "workspace:*",
+    "@galaxy-tool-util/tool-xml": "workspace:*",
     "ajv": "^8.18.0",
     "commander": "^14.0.0",
     "effect": "^3.21.0",

--- a/packages/cli/spec/galaxy-tool-cache.json
+++ b/packages/cli/spec/galaxy-tool-cache.json
@@ -29,6 +29,31 @@
       ]
     },
     {
+      "name": "add-local",
+      "description": "Parse a local tool file (XML or YAML) and cache it (source: local)",
+      "handler": "addLocal",
+      "args": [
+        {
+          "raw": "<tool_path>",
+          "description": "Path to a tool file (.xml or .yml)"
+        }
+      ],
+      "options": [
+        {
+          "flags": "--tool-id <id>",
+          "description": "Full toolshed tool_id for cache keying (required; the bare XML id is not a valid key)"
+        },
+        {
+          "flags": "--tool-version <ver>",
+          "description": "Tool version (overrides the parsed version)"
+        },
+        {
+          "flags": "--cache-dir <dir>",
+          "description": "Cache directory"
+        }
+      ]
+    },
+    {
       "name": "list",
       "description": "List cached tools with their resolved versions",
       "handler": "list",

--- a/packages/cli/src/commands/add-local.ts
+++ b/packages/cli/src/commands/add-local.ts
@@ -1,0 +1,52 @@
+import { makeNodeToolInfoService } from "@galaxy-tool-util/core/node";
+import { loadToolFile } from "@galaxy-tool-util/tool-xml";
+
+export interface AddLocalOptions {
+  toolId?: string;
+  toolVersion?: string;
+  cacheDir?: string;
+}
+
+/**
+ * Cache a tool parsed from a local file — the local-ingest counterpart to `add`
+ * (which fetches from the ToolShed). Dispatches on extension like Galaxy's
+ * `get_tool_source` (`.yml` → YAML, else → XML; CWL unsupported). Mirrors
+ * Galaxy's `run_add_local`: a bare `<tool id>` is not a valid cache key, so
+ * `--tool-id` (the full toolshed tool_id) is required even when the file carries
+ * an id; the parsed id is surfaced only as a hint.
+ */
+export async function runAddLocal(toolPath: string, opts: AddLocalOptions): Promise<void> {
+  let parsed;
+  try {
+    parsed = loadToolFile(toolPath);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to parse ${toolPath}: ${msg}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const toolId = opts.toolId;
+  if (toolId == null) {
+    if (parsed.id && parsed.version) {
+      console.log(`Parsed tool: ${parsed.id} v${parsed.version}`);
+      console.log("Use --tool-id to specify the full toolshed tool_id for proper cache keying.");
+      process.exitCode = 1;
+      return;
+    }
+    console.error("Cannot determine tool_id from tool file. Use --tool-id.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const version = opts.toolVersion || parsed.version;
+  if (version == null) {
+    console.error("Cannot determine version. Use --tool-version.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const service = makeNodeToolInfoService({ cacheDir: opts.cacheDir });
+  await service.addTool(toolId, version, parsed, "local", toolPath);
+  console.log(`Cached ${toolId} ${version} from ${toolPath}`);
+}

--- a/packages/cli/src/programs/galaxy-tool-cache.ts
+++ b/packages/cli/src/programs/galaxy-tool-cache.ts
@@ -4,6 +4,7 @@
  */
 import type { Command } from "commander";
 import { runAdd } from "../commands/add.js";
+import { runAddLocal } from "../commands/add-local.js";
 import { runList } from "../commands/list.js";
 import { runInfo } from "../commands/info.js";
 import { runClear } from "../commands/clear.js";
@@ -15,6 +16,7 @@ import { galaxyToolCacheSpec } from "../meta/specs.js";
 
 const handlers: HandlerRegistry = {
   add: runAdd,
+  addLocal: runAddLocal,
   list: runList,
   info: runInfo,
   clear: runClear,

--- a/packages/cli/test/add-local.test.ts
+++ b/packages/cli/test/add-local.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { makeNodeToolCache } from "@galaxy-tool-util/core/node";
+import { runAddLocal } from "../src/commands/add-local.js";
+import { createCliTestContext, type CliTestContext } from "./helpers/cli-test-context.js";
+
+const SHED_ID = "toolshed.g2.bx.psu.edu/repos/devteam/cat/cat1";
+
+/** Minimal valid tool XML (id + version), optionally dropping the version attr. */
+function toolXml(opts: { version?: string } = {}): string {
+  const ver = opts.version === undefined ? "" : ` version="${opts.version}"`;
+  return `<tool id="cat1" name="Concatenate"${ver} profile="23.0"/>`;
+}
+
+describe("galaxy-tool-cache add-local", () => {
+  let ctx: CliTestContext;
+
+  beforeEach(async () => {
+    ctx = await createCliTestContext("add-local-test");
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function writeTool(name: string, xml: string): Promise<string> {
+    const path = join(ctx.tmpDir, name);
+    await writeFile(path, xml, "utf-8");
+    return path;
+  }
+
+  const logged = (): string => ctx.logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  const errored = (): string => ctx.errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+
+  it("parses a local XML tool and caches it under the given --tool-id", async () => {
+    const path = await writeTool("cat.xml", toolXml({ version: "1.0.0" }));
+
+    await runAddLocal(path, { toolId: SHED_ID, cacheDir: ctx.tmpDir });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(logged()).toContain(`Cached ${SHED_ID} 1.0.0 from ${path}`);
+
+    const cache = makeNodeToolCache({ cacheDir: ctx.tmpDir });
+    expect(await cache.hasCached(SHED_ID, "1.0.0")).toBe(true);
+  });
+
+  it("parses a local YAML tool (dispatches on .yml extension)", async () => {
+    const yml = ["class: GalaxyUserTool", "id: cat1", "name: Concatenate", "version: 2.0.0"].join(
+      "\n",
+    );
+    const path = await writeTool("cat.yml", yml);
+
+    await runAddLocal(path, { toolId: SHED_ID, cacheDir: ctx.tmpDir });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(logged()).toContain(`Cached ${SHED_ID} 2.0.0 from ${path}`);
+    const cache = makeNodeToolCache({ cacheDir: ctx.tmpDir });
+    expect(await cache.hasCached(SHED_ID, "2.0.0")).toBe(true);
+  });
+
+  it("lets --tool-version override the parsed version", async () => {
+    const path = await writeTool("cat.xml", toolXml({ version: "1.0.0" }));
+
+    await runAddLocal(path, { toolId: SHED_ID, toolVersion: "9.9.9", cacheDir: ctx.tmpDir });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(logged()).toContain(`Cached ${SHED_ID} 9.9.9 from ${path}`);
+    const cache = makeNodeToolCache({ cacheDir: ctx.tmpDir });
+    expect(await cache.hasCached(SHED_ID, "9.9.9")).toBe(true);
+  });
+
+  it("refuses without --tool-id even when the XML has an id, surfacing the parsed id", async () => {
+    const path = await writeTool("cat.xml", toolXml({ version: "1.0.0" }));
+
+    await runAddLocal(path, { cacheDir: ctx.tmpDir });
+
+    expect(process.exitCode).toBe(1);
+    expect(logged()).toContain("Parsed tool: cat1 v1.0.0");
+    expect(logged()).toContain("Use --tool-id");
+    const cache = makeNodeToolCache({ cacheDir: ctx.tmpDir });
+    expect(await cache.hasCached(SHED_ID, "1.0.0")).toBe(false);
+  });
+
+  it("errors when --tool-id is given but no version can be determined", async () => {
+    const path = await writeTool("cat.xml", toolXml());
+
+    await runAddLocal(path, { toolId: SHED_ID, cacheDir: ctx.tmpDir });
+
+    expect(process.exitCode).toBe(1);
+    expect(errored()).toContain("Cannot determine version. Use --tool-version.");
+  });
+
+  it("errors when the file cannot be parsed as a tool", async () => {
+    const path = await writeTool("broken.xml", "<toolbox></toolbox>");
+
+    await runAddLocal(path, { toolId: SHED_ID, cacheDir: ctx.tmpDir });
+
+    expect(process.exitCode).toBe(1);
+    expect(errored()).toContain(`Failed to parse ${path}`);
+  });
+});

--- a/packages/tool-xml/package.json
+++ b/packages/tool-xml/package.json
@@ -43,11 +43,11 @@
   "license": "MIT",
   "dependencies": {
     "@galaxy-tool-util/schema": "workspace:*",
-    "fast-xml-parser": "^5.10.1"
+    "fast-xml-parser": "^5.10.1",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "effect": "^3.21.0",
-    "yaml": "^2.8.3"
+    "effect": "^3.21.0"
   }
 }

--- a/packages/tool-xml/src/index.ts
+++ b/packages/tool-xml/src/index.ts
@@ -15,4 +15,10 @@ export {
 } from "./tool-source.js";
 export { parseOutputs } from "./outputs.js";
 export { parseInputs, XmlPageSource, XmlInputSource } from "./inputs.js";
-export { parseXmlTool, loadXmlTool, parsedToolFromSource } from "./parse.js";
+export {
+  parseXmlTool,
+  loadXmlTool,
+  loadYamlTool,
+  loadToolFile,
+  parsedToolFromSource,
+} from "./parse.js";

--- a/packages/tool-xml/src/parse.ts
+++ b/packages/tool-xml/src/parse.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from "node:fs";
+
 import * as S from "effect/Schema";
-import { ParsedTool } from "@galaxy-tool-util/schema";
+import * as yaml from "yaml";
+import { ParsedTool, parseYamlTool } from "@galaxy-tool-util/schema";
 import type { ParsedTool as ParsedToolType } from "@galaxy-tool-util/schema";
 
 import type { ImportResolver } from "./macros.js";
@@ -41,4 +44,32 @@ export function parseXmlTool(text: string, importResolver: ImportResolver): Pars
 /** Load an XML tool file from disk and parse it into a validated {@link ParsedToolType}. */
 export function loadXmlTool(path: string): ParsedToolType {
   return parsedToolFromSource(loadXmlToolSource(path));
+}
+
+/**
+ * Load a tool file from disk and parse it into a validated {@link ParsedToolType},
+ * dispatching on extension like Galaxy's ``get_tool_source``: ``.yml`` is a YAML
+ * tool source, everything else is XML. CWL (``.cwl``/``.json``) is not supported.
+ */
+export function loadToolFile(path: string): ParsedToolType {
+  if (path.endsWith(".cwl") || path.endsWith(".json")) {
+    throw new Error(`CWL tools are not supported: ${path}`);
+  }
+  if (path.endsWith(".yml")) {
+    return loadYamlTool(path);
+  }
+  return loadXmlTool(path);
+}
+
+/** Load a YAML tool file from disk and parse it into a validated {@link ParsedToolType}. */
+export function loadYamlTool(path: string): ParsedToolType {
+  const text = readFileSync(path, "utf-8");
+  const repr = yaml.parse(text) as Record<string, unknown>;
+  // PyYAML renders a float version (`1.0`) as "1.0"; JS yaml collapses it to the
+  // number 1, so `String(version)` would yield "1". Recover the written token.
+  if (repr && typeof repr === "object" && typeof repr.version === "number") {
+    const node = yaml.parseDocument(text).get("version", true) as { source?: unknown } | undefined;
+    if (node && typeof node.source === "string") repr.version = node.source;
+  }
+  return parseYamlTool(repr);
 }

--- a/packages/tool-xml/test/declarative-parsing.test.ts
+++ b/packages/tool-xml/test/declarative-parsing.test.ts
@@ -10,22 +10,21 @@
  *   - explicit `.xml`/`.yml` suffix → that file
  *   - trailing `_y` → `<stem>.yml`
  *   - otherwise → `<name>.xml`
- * XML fixtures parse via `loadXmlToolSource`; YAML tools via `parseYamlTool`.
+ * `loadToolFile` then dispatches on extension (XML vs YAML) — the same loader the
+ * `galaxy-tool-cache add-local` command uses, so the CLI and this parity suite
+ * cannot drift on how a tool file becomes a `ParsedTool`.
  *
  * The assertion engine is shared with the workflow declarative suites — imported
  * from the schema package's test helpers rather than duplicated. `parse_tool`
  * already emits snake_case (`ParsedTool`), so results feed the runner directly.
  */
 import { describe, expect, it } from "vitest";
-import * as yaml from "yaml";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { parseYamlTool } from "@galaxy-tool-util/schema";
-
 import { loadExpectations, runAssertions } from "../../schema/test/declarative-test-utils.js";
 
-import { loadXmlTool } from "../src/index.js";
+import { loadToolFile } from "../src/index.js";
 
 const FIXTURES_DIR = path.join(import.meta.dirname, "fixtures", "tool_parsing");
 const EXPECTATIONS_DIR = path.join(FIXTURES_DIR, "expectations");
@@ -48,27 +47,9 @@ function resolveFixturePath(name: string): string {
   return path.join(TOOLS_DIR, file);
 }
 
-/** Parse an XML tool file into a validated `ParsedTool` (mirrors Python `parse_tool`). */
-function parseXmlFixture(filePath: string): unknown {
-  return loadXmlTool(filePath);
-}
-
-/** Parse a YAML tool document, preserving the declared version's source token. */
-function parseYamlFixture(filePath: string): unknown {
-  const text = fs.readFileSync(filePath, "utf-8");
-  const repr = yaml.parse(text) as Record<string, unknown>;
-  // PyYAML renders a float version (`1.0`) as "1.0"; JS collapses it to the
-  // number 1, so `String(version)` would yield "1". Recover the written token.
-  if (repr && typeof repr === "object" && typeof repr.version === "number") {
-    const node = yaml.parseDocument(text).get("version", true) as { source?: unknown } | undefined;
-    if (node && typeof node.source === "string") repr.version = node.source;
-  }
-  return parseYamlTool(repr);
-}
-
+/** Parse a fixture (XML or YAML) into a validated `ParsedTool` (mirrors Python `parse_tool`). */
 function parseFixture(name: string): unknown {
-  const filePath = resolveFixturePath(name);
-  return filePath.endsWith(".yml") ? parseYamlFixture(filePath) : parseXmlFixture(filePath);
+  return loadToolFile(resolveFixturePath(name));
 }
 
 const ALL_CASES = loadExpectations(EXPECTATIONS_DIR);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@galaxy-tool-util/search':
         specifier: workspace:*
         version: link:../search
+      '@galaxy-tool-util/tool-xml':
+        specifier: workspace:*
+        version: link:../tool-xml
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -406,6 +409,9 @@ importers:
       fast-xml-parser:
         specifier: ^5.10.1
         version: 5.10.1
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
@@ -413,9 +419,6 @@ importers:
       effect:
         specifier: ^3.21.0
         version: 3.21.0
-      yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
 
   packages/workflow-graph:
     devDependencies:


### PR DESCRIPTION
> 🤖 PR description drafted by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally.

## `galaxy-tool-cache add-local` — cache a tool from a local file

Wires the `@galaxy-tool-util/tool-xml` parser (from #158/#159) into the CLI — the downstream consumer that issue #158 named (`schema ← tool-xml ← cli`). Ports Galaxy's `galaxy-tool-cache add-local`: parse a local tool file into a `ParsedTool` and cache it with `source: local`, the local-ingest counterpart to `add` (which fetches from the ToolShed).

### Behavior (mirrors Python `run_add_local`)

```
add-local <tool_path> [--tool-id <full_shed_id>] [--tool-version <ver>] [--cache-dir <dir>]
```

- Dispatches on extension like Galaxy's `get_tool_source`: **`.yml` → YAML**, everything else → **XML**. (CWL `.cwl`/`.json` is unsupported — a clear error rather than a confusing XML parse failure.)
- **`--tool-id` is required for cache keying** even when the file carries a bare `<tool id>` — a bare local id isn't a valid toolshed key, so the parsed id is surfaced only as a hint and the command exits non-zero.
- `--tool-version` overrides the parsed version; if neither exists, exits with `Cannot determine version`.

### Shared loader (no drift)

New `loadToolFile(path)` in `tool-xml` (the extension dispatcher, mirroring `parse_tool(get_tool_source(path))`) is used by **both** `add-local` and the declarative cross-language parity suite, which was refactored to route through it. So the CLI and the Python-parity tests can't diverge on how a tool file becomes a `ParsedTool`. Also exports `loadYamlTool(path)`.

### Testing

- `packages/cli/test/add-local.test.ts` — 6 cases: XML + YAML happy paths, `--tool-version` override, the three exit-1 guards (no `--tool-id`, no version, unparseable file).
- `spec-parity` green (new command matches the in-code builder); declarative parsing suite still 31/31 after the loader refactor.
- `make check` clean; full `cli` (358) + `tool-xml` (109) suites pass. Changeset included (`cli` + `tool-xml` minor).

### Scope

- **In:** local XML + YAML ingest, faithful to Python's flag/exit semantics.
- **Out:** CWL (deferred on both sides — Python nominally accepts it but flags it non-functional). Other Python-only `galaxy-tool-cache` subcommands (`list-inline-tools`, `embedded-schema`, `structural-schema`) remain a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
